### PR TITLE
Fix for tooltip appearing off the top

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Scripts/VoteAppPages/Results.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/VoteAppPages/Results.js
@@ -52,8 +52,15 @@
             return d.Count;
         })
         .tooltipFunction(function (d) {
-            return "Votes: " + d.Count + "<br />" +  d.Voters.toString().replace(/,/g, "<br />");
+            var maxToDisplay = 5;
+            if (d.Count <= maxToDisplay) {
+                return "Votes: " + d.Count + "<br />" + d.Voters.toString().replace(/,/g, "<br />");
+            }
+            else {
+                return "Votes: " + d.Count + "<br />" + d.Voters.slice(0, maxToDisplay).toString().replace(/,/g, "<br />") + "<br />" + "+ " + (d.Count - maxToDisplay) + " others";
+            }
         });
+
         chart.series([series]);
 
         chart.draw();


### PR DESCRIPTION
After 5 users, the tooltip is clipped to only show the first 5 users,
then lists how many other users have voted on the item.

For 5 or below, the appearance is the same as before.
