### PR TITLE
Fix redirect loops

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Scripts/Home.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/Home.js
@@ -22,7 +22,7 @@
                     
                     localStorage["userId"] = JSON.stringify({ id: userId, expires: expiryTime });
                     $('#loginForm').addClass("has-success");
-                    window.location = "vote?session=" + self.sessionId;
+                    window.location.replace("vote?session=" + self.sessionId);
                 },
 
                 error: function (jqXHR, textStatus, errorThrown) {
@@ -94,7 +94,7 @@
                 $("#sessions").hide();
                 $("#login-box").show();
             } else {
-                window.location = "vote/?session=" + self.sessionId;
+                window.location.replace("vote?session=" + self.sessionId);
             }
         });
     }

--- a/VotingApplication/VotingApplication.Web.Api/VotingApplication.Web.Api.csproj
+++ b/VotingApplication/VotingApplication.Web.Api/VotingApplication.Web.Api.csproj
@@ -337,7 +337,6 @@
     </Content>
     <Content Include="Scripts\Vote.js" />
     <Content Include="Scripts\Results.js" />
-    <Content Include="Scripts\Vote.js" />
     <Content Include="Web.config" />
     <Content Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>


### PR DESCRIPTION
Using "window.location.replace" instead of "window.location =" replaces
the location in the browser history, meaning we can press the "Back"
button without being redirected back to where we were.

Also noticed that the Vote.js script occurs twice in the csproj, so
we remove the duplicate reference
