### PR TITLE
Hide Descriptions when small

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Partials/VotingStrategies/PointsVote.html
+++ b/VotingApplication/VotingApplication.Web.Api/Partials/VotingStrategies/PointsVote.html
@@ -10,7 +10,7 @@
     <tbody data-bind="foreach: options">
         <tr>
             <td data-bind="text: Name"></td>
-            <td data-bind="text: Description"></td>
+            <td class="hidden-xs" data-bind="text: Description"></td>
             <td class="hidden-xs hidden-sm" data-bind="text: Info"></td>
             <td>
                 <span class="btn-group">


### PR DESCRIPTION
On the iPhone, we don't have much screen space so want to use as much as
possible.
