### PR TITLE
Be less strict on username in emails

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Partials/Create.html
+++ b/VotingApplication/VotingApplication.Web.Api/Partials/Create.html
@@ -16,7 +16,7 @@
 
         <div id="email-group">
             <label class="control-label" for="email">Creator Email</label>
-            <input class="form-control" type="email" id="email" placeholder="E.g. email@example.com" pattern="\w+@\w+(\.\w+)+">
+            <input class="form-control" type="email" id="email" placeholder="E.g. email@example.com" pattern="[\w._%+-]+@\w+(\.\w+)+">
         </div>
 
         <div id="invites-group">


### PR DESCRIPTION
Allows ".", "_", "%", "+" and "-" in usernames.
