### PR TITLE
Fix small screen links

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Styling/style.css
+++ b/VotingApplication/VotingApplication.Web.Api/Styling/style.css
@@ -122,3 +122,13 @@ label {
     border-color: #ddd;
     border-style: solid;
 }
+
+.navbar-nav {
+    float: left;
+    margin: 0;
+}
+
+.navbar-nav>li>a {
+    padding-top: 15px;
+    padding-bottom: 15px;
+}


### PR DESCRIPTION
Bootstrap was changing its layout if the screen width < 768px, which
obscured the buttons.
