### PR TITLE
Avoid repeatedly updating results if nothing has changed

### DIFF
--- a/VotingApplication/VotingApplication.Data/Model/Poll.cs
+++ b/VotingApplication/VotingApplication.Data/Model/Poll.cs
@@ -42,5 +42,7 @@ namespace VotingApplication.Data.Model
         public DateTimeOffset ExpiryDate { get; set; }
 
         public bool OptionAdding { get; set; }
+
+        public DateTime LastUpdated { get; set; }
     }
 }

--- a/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/PollVoteControllerTests.cs
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/PollVoteControllerTests.cs
@@ -42,7 +42,7 @@ namespace VotingApplication.Web.Api.Tests.Controllers
             _emptyUUID = Guid.NewGuid();
             _anonymousUUID = Guid.NewGuid();
 
-            Poll mainPoll = new Poll() { UUID = _mainUUID };
+            Poll mainPoll = new Poll() { UUID = _mainUUID, LastUpdated = DateTime.Today };
             Poll otherPoll = new Poll() { UUID = _otherUUID };
             Poll emptyPoll = new Poll() { UUID = _emptyUUID };
             Poll anonymousPoll = new Poll() { UUID = _anonymousUUID };
@@ -139,16 +139,6 @@ namespace VotingApplication.Web.Api.Tests.Controllers
         }
 
         [TestMethod]
-        public void GetByIdIsNotAllowed()
-        {
-            // Act
-            var response = _controller.Get(_mainUUID, 1);
-
-            // Assert
-            Assert.AreEqual(HttpStatusCode.MethodNotAllowed, response.StatusCode);
-        }
-
-        [TestMethod]
         public void GetOnAnonPollDoesNotReturnUsernames()
         {
             // Act
@@ -158,6 +148,59 @@ namespace VotingApplication.Web.Api.Tests.Controllers
             List<Vote> responseVotes = ((ObjectContent)response.Content).Value as List<Vote>;
             Assert.AreEqual(1, responseVotes.Count);
             Assert.IsNull(responseVotes[0].User);
+        }
+
+        [TestMethod]
+        public void GetWithLowTimestampReturnsResults()
+        {
+            // Act
+            Uri requestURI;
+            Uri.TryCreate("http://localhost/?lastPoll=0", UriKind.Absolute, out requestURI);
+            _controller.Request.RequestUri = requestURI;
+            var response = _controller.Get(_mainUUID);
+
+            // Assert
+            List<Vote> expectedVotes = new List<Vote>();
+            expectedVotes.Add(_bobVote);
+            expectedVotes.Add(_joeVote);
+            List<Vote> responseVotes = ((ObjectContent)response.Content).Value as List<Vote>;
+            CollectionAssert.AreEquivalent(expectedVotes, responseVotes);
+        }
+
+        [TestMethod]
+        public void GetWithHighTimestampReturnsNotModified()
+        {
+            // Act
+            Uri requestURI;
+            Uri.TryCreate("http://localhost/?lastPoll=" + DateTime.MaxValue.ToFileTimeUtc(), UriKind.Absolute, out requestURI);
+            _controller.Request.RequestUri = requestURI;
+            var response = _controller.Get(_mainUUID);
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.NotModified, response.StatusCode);
+        }
+
+        [TestMethod]
+        public void GetWithHighTimestampReturnsNoResults()
+        {
+            // Act
+            Uri requestURI;
+            Uri.TryCreate("http://localhost/?lastPoll=" + DateTime.MaxValue.ToFileTimeUtc(), UriKind.Absolute, out requestURI);
+            _controller.Request.RequestUri = requestURI;
+            var response = _controller.Get(_mainUUID);
+
+            // Assert
+            Assert.IsNull(response.Content);
+        }
+
+        [TestMethod]
+        public void GetByIdIsNotAllowed()
+        {
+            // Act
+            var response = _controller.Get(_mainUUID, 1);
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.MethodNotAllowed, response.StatusCode);
         }
 
         #endregion

--- a/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/PollVoteControllerTests.cs
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/PollVoteControllerTests.cs
@@ -172,7 +172,7 @@ namespace VotingApplication.Web.Api.Tests.Controllers
         {
             // Act
             Uri requestURI;
-            Uri.TryCreate("http://localhost/?lastPoll=" + DateTime.MaxValue.ToFileTimeUtc(), UriKind.Absolute, out requestURI);
+            Uri.TryCreate("http://localhost/?lastPoll=2145916800000", UriKind.Absolute, out requestURI);
             _controller.Request.RequestUri = requestURI;
             var response = _controller.Get(_mainUUID);
 
@@ -185,7 +185,7 @@ namespace VotingApplication.Web.Api.Tests.Controllers
         {
             // Act
             Uri requestURI;
-            Uri.TryCreate("http://localhost/?lastPoll=" + DateTime.MaxValue.ToFileTimeUtc(), UriKind.Absolute, out requestURI);
+            Uri.TryCreate("http://localhost/?lastPoll=2145916800000", UriKind.Absolute, out requestURI);
             _controller.Request.RequestUri = requestURI;
             var response = _controller.Get(_mainUUID);
 

--- a/VotingApplication/VotingApplication.Web.Api/Controllers/API Controllers/PollVoteController.cs
+++ b/VotingApplication/VotingApplication.Web.Api/Controllers/API Controllers/PollVoteController.cs
@@ -36,7 +36,7 @@ namespace VotingApplication.Web.Api.Controllers.API_Controllers
 
                     if (lastPolledDate != null)
                     {
-                        clientLastUpdated = DateTime.FromFileTimeUtc(long.Parse(lastPolledDate));
+                        clientLastUpdated = UnixTimeToDateTime(long.Parse(lastPolledDate));
                     }
 
                     if (poll.LastUpdated.CompareTo(clientLastUpdated) < 0)
@@ -67,6 +67,13 @@ namespace VotingApplication.Web.Api.Controllers.API_Controllers
         public virtual HttpResponseMessage Get(Guid pollId, long voteId)
         {
             return this.Request.CreateErrorResponse(HttpStatusCode.MethodNotAllowed, "Cannot use GET by id on this controller");
+        }
+
+        private static DateTime UnixTimeToDateTime(double unixTimestamp)
+        {
+            DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            dateTime = dateTime.AddMilliseconds(unixTimestamp);
+            return dateTime;
         }
 
         #endregion

--- a/VotingApplication/VotingApplication.Web.Api/Controllers/API Controllers/PollVoteController.cs
+++ b/VotingApplication/VotingApplication.Web.Api/Controllers/API Controllers/PollVoteController.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Data.Entity;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Web;
 using VotingApplication.Data.Context;
 using VotingApplication.Data.Model;
-using VotingApplication.Web.Api.Filters;
 
 namespace VotingApplication.Web.Api.Controllers.API_Controllers
 {
@@ -25,6 +26,23 @@ namespace VotingApplication.Web.Api.Controllers.API_Controllers
                 if (poll == null)
                 {
                     return this.Request.CreateErrorResponse(HttpStatusCode.NotFound, string.Format("Poll {0} not found", pollId));
+                }
+
+                DateTime clientLastUpdated = DateTime.MinValue;
+                if (this.Request.RequestUri != null && this.Request.RequestUri.Query != null)
+                {
+                    NameValueCollection queryMap = HttpUtility.ParseQueryString(this.Request.RequestUri.Query);
+                    string lastPolledDate = queryMap["lastPoll"];
+
+                    if (lastPolledDate != null)
+                    {
+                        clientLastUpdated = DateTime.FromFileTimeUtc(long.Parse(lastPolledDate));
+                    }
+
+                    if (poll.LastUpdated.CompareTo(clientLastUpdated) < 0)
+                    {
+                        return this.Request.CreateResponse(HttpStatusCode.NotModified);
+                    }
                 }
 
                 List<Vote> pollVotes;

--- a/VotingApplication/VotingApplication.Web.Api/Controllers/API Controllers/UserVoteController.cs
+++ b/VotingApplication/VotingApplication.Web.Api/Controllers/API Controllers/UserVoteController.cs
@@ -137,6 +137,8 @@ namespace VotingApplication.Web.Api.Controllers
                     }
 
                     vote.UserId = userId;
+
+                    poll.LastUpdated = DateTime.UtcNow;
                 }
 
                 foreach (Vote vote in votes)

--- a/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/BasicVote.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/BasicVote.js
@@ -7,7 +7,6 @@
         self.options = ko.observableArray(options);
         self.optionAdding = ko.observable(pollData.OptionAdding);
         var chart;
-        var lastResultsRequest = 0;
 
         var anonymousPoll = pollData.AnonymousVoting;
 
@@ -160,22 +159,10 @@
             });
         };
 
-        self.getResults = function (pollId) {
-            $.ajax({
-                type: 'GET',
-                url: '/api/poll/' + pollId + '/vote?lastPoll=' + lastResultsRequest,
- 
-                statusCode: { 
-                    200: function (data) {
-                        var groupedVotes = countVotes(data);
-                        lastResultsRequest = Date.now();
-                        drawChart(groupedVotes);
-                    }
-                },
-
-                error: Common.handleError
-            });
-        };
+        self.displayResults = function (data) {
+            var groupedVotes = countVotes(data);
+            drawChart(groupedVotes);
+        }
 
         self.addOption = function () {
             //Don't submit without an entry in the name field

--- a/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/BasicVote.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/BasicVote.js
@@ -7,6 +7,7 @@
         self.options = ko.observableArray(options);
         self.optionAdding = ko.observable(pollData.OptionAdding);
         var chart;
+        var lastResultsRequest = 0;
 
         var anonymousPoll = pollData.AnonymousVoting;
 
@@ -162,11 +163,14 @@
         self.getResults = function (pollId) {
             $.ajax({
                 type: 'GET',
-                url: '/api/poll/' + pollId + '/vote',
-
-                success: function (data) {
-                    var groupedVotes = countVotes(data);
-                    drawChart(groupedVotes);
+                url: '/api/poll/' + pollId + '/vote?lastPoll=' + lastResultsRequest,
+ 
+                statusCode: { 
+                    200: function (data) {
+                        var groupedVotes = countVotes(data);
+                        lastResultsRequest = Date.now();
+                        drawChart(groupedVotes);
+                    }
                 },
 
                 error: Common.handleError

--- a/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/PointsVote.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/PointsVote.js
@@ -11,7 +11,6 @@
         self.optionAdding = ko.observable(pollData.OptionAdding);
 
         var chart;
-        var lastResultsRequest = 0;
 
         self.pointsRemaining = ko.computed(function () {
             var total = 0;
@@ -251,22 +250,10 @@
             });
         };
 
-        self.getResults = function (pollId) {
-            $.ajax({
-                type: 'GET',
-                url: '/api/poll/' + pollId + '/vote?lastPoll=' + lastResultsRequest,
-
-                statusCode: {
-                    200: function (data) {
-                        var groupedVotes = countVotes(data);
-                        lastResultsRequest = Date.now();
-                        drawChart(groupedVotes);
-                    }
-                },
-
-                error: Common.handleError
-            });
-        };
+        self.displayResults = function(data) {
+            var groupedVotes = countVotes(data);
+            drawChart(groupedVotes);
+        }
 
         self.addOption = function () {
             //Don't submit without an entry in the name field

--- a/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/PointsVote.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/PointsVote.js
@@ -11,6 +11,7 @@
         self.optionAdding = ko.observable(pollData.OptionAdding);
 
         var chart;
+        var lastResultsRequest = 0;
 
         self.pointsRemaining = ko.computed(function () {
             var total = 0;
@@ -253,11 +254,14 @@
         self.getResults = function (pollId) {
             $.ajax({
                 type: 'GET',
-                url: '/api/poll/' + pollId + '/vote',
+                url: '/api/poll/' + pollId + '/vote?lastPoll=' + lastResultsRequest,
 
-                success: function (data) {
-                    var groupedVotes = countVotes(data);
-                    drawChart(groupedVotes);
+                statusCode: {
+                    200: function (data) {
+                        var groupedVotes = countVotes(data);
+                        lastResultsRequest = Date.now();
+                        drawChart(groupedVotes);
+                    }
                 },
 
                 error: Common.handleError

--- a/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/RankedVote.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/RankedVote.js
@@ -13,7 +13,6 @@
         var orderedNames = [];
         var chart;
         var roundIndex = 0;
-        var lastResultsRequest = 0;
 
         var selectOption = function (option) {
             var $option = $('#optionTable-tbody > tr').filter(function () {
@@ -371,22 +370,9 @@
             });
         };
 
-        self.getResults = function (pollId) {
-
-            $.ajax({
-                type: 'GET',
-                url: '/api/poll/' + pollId + '/vote?lastPoll=' + lastResultsRequest,
-
-                statusCode: {
-                    200: function (data) {
-                        lastResultsRequest = Date.now();
-                        displayResults(data);
-                    }
-                },
-
-                error: Common.handleError
-            });
-        };
+        self.displayResults = function (data) {
+            displayResults(data);
+        }
 
         self.addOption = function () {
             //Don't submit without an entry in the name field

--- a/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/RankedVote.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/VotingStrategies/RankedVote.js
@@ -13,6 +13,7 @@
         var orderedNames = [];
         var chart;
         var roundIndex = 0;
+        var lastResultsRequest = 0;
 
         var selectOption = function (option) {
             var $option = $('#optionTable-tbody > tr').filter(function () {
@@ -374,10 +375,13 @@
 
             $.ajax({
                 type: 'GET',
-                url: '/api/poll/' + pollId + '/vote',
+                url: '/api/poll/' + pollId + '/vote?lastPoll=' + lastResultsRequest,
 
-                success: function (data) {
-                    displayResults(data);
+                statusCode: {
+                    200: function (data) {
+                        lastResultsRequest = Date.now();
+                        displayResults(data);
+                    }
                 },
 
                 error: Common.handleError


### PR DESCRIPTION
Adds a timestamp to polls, specifying the last time the poll was updated.
When requesting the results from the poll we check against this value to see if anything has changed since the last request.