### PR TITLE
Fix for tabbing issue on Create page

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Views/Create/Index.cshtml
+++ b/VotingApplication/VotingApplication.Web.Api/Views/Create/Index.cshtml
@@ -68,7 +68,7 @@
                     <div class="col-md-6">
                         <div id="strategy-group" class="form-group">
                             <label class="control-label" for="voting-strategy">Poll type</label>
-                            <a href="/info" id="strategy-info" class="help-message">[?]</a>
+                            <a id="strategy-info" class="help-message">[?]</a>
                             <div class="tip" data-bind="hoverTargetId:strategy-info">
                                 <p><b>Single Vote</b>:<br />Pick one option</p>
                                 <p>
@@ -94,9 +94,6 @@
                             <label class="control-label" for="max-per-vote">Max points per vote</label>
                             <input class="form-control" id="max-per-vote" placeholder="3" data-bind="value: maxPerVote" />
                         </div>
-                    </div>
-                    <div class="col-md-1"></div>
-                    <div class="col-md-6">
 
                         <div id="invite-group" class="form-group">
                             <label class="control-label" for="invite-only">Invite only</label>


### PR DESCRIPTION
By having a href on the Strategy [?] info box, we could tab to it but
not to any other tooltip.

The link wasn't really required, so we remove it.

Also straightens out the div types from a previous merge conflict which
had left the Strategy type in a section of its own.