### PR TITLE
Fixed drag-drop problem in Ranked Vote

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/RankedVoteTests.js
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/RankedVoteTests.js
@@ -31,23 +31,7 @@
 
         });
         //#endregion
-
-        it("remainOptions with Selected Options expect Non-selected Options", function () {
-            // arrange
-            target.pollOptions.options([
-                    { Id: 13, Name: "Option-1" }, { Id: 17, Name: "Option-2" },
-                    { Id: 21, Name: "Option-3" }, { Id: 25, Name: "Option-4" }
-                ]);
-
-            target.selectedOptions([{ Id: 17, Name: "Option-2" }, { Id: 25, Name: "Option-4" }]);
-
-            // act
-            var result = target.remainOptions();
-
-            // assert
-            expect(result).toEqual([{ Id: 13, Name: "Option-1" }, { Id: 21, Name: "Option-3" }]);
-        });
-
+        
         it("doVote with Token expect Post vote and notify", function (done) {
             // arrange
 
@@ -108,7 +92,8 @@
 
         it("getVotes without Voted expect Clear selected", function (done) {
             // arrange
-            target.pollOptions.options([{ Id: 13, Name: "Option-1" }, { Id: 17, Name: "Option-2" }]);
+            target.pollOptions.options([{ Id: 13, Name: "Option-1" }, { Id: 17, Name: "Option-2" }, { Id: 21, Name: "Option-3" }]);
+            target.selectedOptions([{ Id: 13, Name: "Option-1" }, { Id: 21, Name: "Option-3" }]);
             target.selectedOptions([{ Id: 17, Name: "Option-2" }]);
 
             mockjax({
@@ -123,6 +108,7 @@
             setTimeout(function () {
                 // Neither should be highlighted
                 expect(target.selectedOptions().length).toEqual(0);
+                expect(target.remainOptions()).toEqual([{ Id: 13, Name: "Option-1" }, { Id: 17, Name: "Option-2" }, { Id: 21, Name: "Option-3" }]);
                 done();
             }, 10);
         });
@@ -130,6 +116,7 @@
         it("getVotes with Voted expect Set selected", function (done) {
             // arrange
             target.pollOptions.options([{ Id: 13, Name: "Option-1" }, { Id: 17, Name: "Option-2" }, { Id: 21, Name: "Option-3" }]);
+            target.selectedOptions([{ Id: 13, Name: "Option-1" }, { Id: 21, Name: "Option-3" }]);
             target.selectedOptions([{ Id: 17, Name: "Option-2" }]);
 
             mockjax({
@@ -144,6 +131,7 @@
             setTimeout(function () {
                 // Neither should be highlighted
                 expect(target.selectedOptions()).toEqual([{ Id: 13, Name: "Option-1" }, { Id: 21, Name: "Option-3" }]);
+                expect(target.remainOptions()).toEqual([{ Id: 17, Name: "Option-2" }]);
                 done();
             }, 10);
         });

--- a/VotingApplication/VotingApplication.Web.Api/Scripts/RankedVote.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/RankedVote.js
@@ -5,30 +5,29 @@
         var self = this;
         self.pollOptions = new PollOptions(pollId);
         self.selectedOptions = ko.observableArray();
+        self.remainOptions = ko.observableArray();
 
         self.resultOptions = ko.observableArray();
 
         self.chartVisible = ko.observable(false);
 
         var selectPickedOptions = function (votes) {
+            self.selectedOptions([]);
+            self.remainOptions([]);
+
             var selected = votes.map(function (vote) {
                 return ko.utils.arrayFirst(self.pollOptions.options(), function (item) {
                     return item.Id === vote.OptionId;
                 });
             });
             self.selectedOptions(selected);
-        };
 
-        // Remaining list of "non-selected" options is created
-        // as a computed array dependant on the selected options
-        // and full set of options
-        self.remainOptions = ko.computed(function () {
             var notSelected = function (option) {
                 return self.selectedOptions().filter(function (o) { return o.Id === option.Id; }).length === 0;
             };
 
-            return self.pollOptions.options().filter(notSelected);
-        });
+            self.remainOptions(self.pollOptions.options().filter(notSelected));
+        };
 
         var resultsByRound = [];
         var orderedNames = [];
@@ -226,17 +225,19 @@
                 connectWith: '.sortable',
                 axis: 'y',
                 dropOnEmpty: true,
-                receive: function () {
+                stop: function () {
                     var votes = [];
                     $('#selectionTable tr.clickable').each(function (i, row) {
                         votes.push({
-                            OptionId: $(row).attr('data-id')
+                            OptionId: parseInt($(row).attr('data-id'))
                         });
                     });
 
                     // Cancel the sort operation and update the Knockout
                     // arrays, letting Knockout re-arrange the DOM
                     $(".sortable").sortable("cancel");
+                    $(".sortable tr.clickable").remove();
+
                     selectPickedOptions(votes);
                 }
             });

--- a/VotingApplication/VotingApplication.Web.Api/Views/Poll/_RankedVotePartial.cshtml
+++ b/VotingApplication/VotingApplication.Web.Api/Views/Poll/_RankedVotePartial.cshtml
@@ -34,20 +34,23 @@
     </div>
     <table id="selectionTable" class="table table-hover sortable selection-content">
         <thead>
-            <tr data-bind="visible: selectedOptions().length == 0">
-                <th colspan="3">Drag options here in preference order</th>
-            </tr>
             <tr>
                 <th class="col-md-3">Option</th>
                 <th class="col-md-6">Description</th>
                 <th class="col-md-3 hidden-xs hidden-sm">More info</th>
             </tr>
         </thead>
-        <tbody data-bind="foreach: selectedOptions">
+        <tbody id="selectionTable-body">
+            <!-- ko foreach: selectedOptions -->
             <tr class="clickable" data-bind="attr: {'data-id': Id}">
                 <td class="col-md-3" data-bind="text: Name"></td>
                 <td class="col-md-6" data-bind="text: Description"></td>
                 <td class="col-md-3 hidden-xs hidden-sm" data-bind="text: Info"></td>
+            </tr>
+            <!-- /ko -->
+
+            <tr data-bind="visible: selectedOptions().length == 0">
+                <td colspan="3">Drag options here in preference order</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
jQuery was messing up the DOM when drag-dropping,
so the new version clears the rows and lets Knockout
re-establish them from empty.