### PR TITLE
Use release mode for live sites

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Web.Debug.config
+++ b/VotingApplication/VotingApplication.Web.Api/Web.Debug.config
@@ -26,5 +26,7 @@
         <error statusCode="500" redirect="InternalError.htm"/>
       </customErrors>
     -->
+    <compilation debug="true" targetFramework="4.5"></compilation>
+
   </system.web>
 </configuration>

--- a/VotingApplication/VotingApplication.Web.Api/Web.config
+++ b/VotingApplication/VotingApplication.Web.Api/Web.config
@@ -21,7 +21,7 @@
   <system.web>
     <customErrors mode="Off" />
     <authentication mode="None" />
-    <compilation debug="true" targetFramework="4.5">
+    <compilation debug="false" targetFramework="4.5">
       <assemblies>
         <!--Application Insights: add System.Runtime assembly to resolve PCL dependencies-->
         <add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />


### PR DESCRIPTION
When building locally, we can select to be in Debug mode.
When deploying to the live site, it will use this setting.
Previously, it was using Debug and therefore not running the Minification
scripts, so couldn't find /Scripts/Min/xyz.js

The Dev site avoided this because it does not use the Minified scripts.