### PR TITLE
Default to compiling in Release mode

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Views/Shared/_Layout.cshtml
+++ b/VotingApplication/VotingApplication.Web.Api/Views/Shared/_Layout.cshtml
@@ -46,7 +46,7 @@
     <script src="/Scripts/Config.js"></script>
 
     @{
-        if (!String.Equals(System.Web.Configuration.WebConfigurationManager.AppSettings["JSDebug"], "true", StringComparison.OrdinalIgnoreCase))
+        if (!System.Diagnostics.Debugger.IsAttached)
         {
             @:<script src="/Scripts/Min/@(ViewBag.ScriptName).js"></script>
         }

--- a/VotingApplication/VotingApplication.Web.Api/VotingApplication.Web.Api.csproj
+++ b/VotingApplication/VotingApplication.Web.Api/VotingApplication.Web.Api.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>
     </ProductVersion>

--- a/VotingApplication/VotingApplication.Web.Api/Web.config
+++ b/VotingApplication/VotingApplication.Web.Api/Web.config
@@ -1,127 +1,126 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301879
   -->
 <configuration>
   <configSections>
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <connectionStrings>
-    <add name="VotingContext" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=VotingApplication;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="VotingContext" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=VotingApplication;Integrated Security=True" providerName="System.Data.SqlClient"/>
   </connectionStrings>
   <appSettings>
-    <add key="HostLogin" value="username" />
-    <add key="HostEmail" value="exampleEmail@scottlogic.co.uk" />
-    <add key="HostPassword" value="examplePassword" />
-    <add key="HostURI" value="example.com" />
-    <add key="JSDebug" value="true" />
+    <add key="HostLogin" value="username"/>
+    <add key="HostEmail" value="exampleEmail@scottlogic.co.uk"/>
+    <add key="HostPassword" value="examplePassword"/>
+    <add key="HostURI" value="example.com"/>
   </appSettings>
   <system.web>
-    <customErrors mode="Off" />
-    <authentication mode="None" />
+    <customErrors mode="Off"/>
+    <authentication mode="None"/>
     <compilation debug="true" targetFramework="4.5">
       <assemblies>
         <!--Application Insights: add System.Runtime assembly to resolve PCL dependencies-->
-        <add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+        <add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
       </assemblies>
     </compilation>
-    <httpRuntime targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5"/>
     <httpModules>
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.RequestTracking.WebRequestTrackingModule, Microsoft.ApplicationInsights.Web" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.RequestTracking.WebRequestTrackingModule, Microsoft.ApplicationInsights.Web"/>
     </httpModules>
   </system.web>
   <system.webServer>
-    <httpErrors errorMode="Detailed" />
+    <httpErrors errorMode="Detailed"/>
     <rewrite>
       <rules>
         <rule name="Redirect to https">
-          <match url="(.*)" />
+          <match url="(.*)"/>
           <conditions>
-            <add input="{HTTPS}" pattern="Off" />
-            <add input="{REQUEST_METHOD}" pattern="^get$|^head$" />
+            <add input="{HTTPS}" pattern="Off"/>
+            <add input="{REQUEST_METHOD}" pattern="^get$|^head$"/>
           </conditions>
-          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" />
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}"/>
         </rule>
       </rules>
     </rewrite>
     
     <modules>
-      <remove name="FormsAuthentication" />
-      <remove name="ApplicationInsightsWebTracking" />
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.RequestTracking.WebRequestTrackingModule, Microsoft.ApplicationInsights.Web" preCondition="managedHandler" />
+      <remove name="FormsAuthentication"/>
+      <remove name="ApplicationInsightsWebTracking"/>
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.RequestTracking.WebRequestTrackingModule, Microsoft.ApplicationInsights.Web" preCondition="managedHandler"/>
     </modules>
     
-    <validation validateIntegratedModeConfiguration="false" />
-  <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    <validation validateIntegratedModeConfiguration="false"/>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.0.0" newVersion="5.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>
     <contexts>
       <context type="VotingApplication.Data.Context.VotingContext, VotingApplication.Data" disableDatabaseInitialization="false">
-        <databaseInitializer type="System.Data.Entity.MigrateDatabaseToLatestVersion`2[[VotingApplication.Data.Context.VotingContext, VotingApplication.Data],                              [VotingApplication.Data.Migrations.Configuration, VotingApplication.Data]], EntityFramework" />
+        <databaseInitializer type="System.Data.Entity.MigrateDatabaseToLatestVersion`2[[VotingApplication.Data.Context.VotingContext, VotingApplication.Data],                              [VotingApplication.Data.Migrations.Configuration, VotingApplication.Data]], EntityFramework"/>
       </context>
     </contexts>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="mssqllocaldb" />
+        <parameter value="mssqllocaldb"/>
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
     </providers>
   </entityFramework>
 </configuration>


### PR DESCRIPTION
By default, if no configuration was specified, the app would build in
Debug mode. This meant that the Min files were not compiled, so the
production site had issues with them.

We also remove the JSDebug script, in favour of only using Min files if
we have attached a debugger. This will allow us to debug things on prod
if necessary, without causing the full files to be used when not required