### PR TITLE
Tweaks to chart/results display

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api/Scripts/ResultChart.js
+++ b/VotingApplication/VotingApplication.Web.Api/Scripts/ResultChart.js
@@ -10,11 +10,12 @@
 
             var dataUnchanged = chart && data.length === chart.series().length;
             var barCount = 0;
-            for (var n = 0; (n < data.length) && dataUnchanged; n++) {
+            for (var n = 0; n < data.length; n++) {
                 barCount += data[n].Data.length;
+                var chartSeries = chart ? chart.series() : null;
                 dataUnchanged = dataUnchanged &&
-                    chart.series().length > n &&
-                    JSON.stringify(data[n].Data) == JSON.stringify(chart.series()[n].Data.rawData());
+                    chart && chart.series().length > n &&
+                    JSON.stringify(data[n].Data) == JSON.stringify(chart.series()[n].data.rawData());
             }
             //Exit early if data has not changed
             if (dataUnchanged)

--- a/VotingApplication/VotingApplication.Web.Api/Views/Poll/Index.cshtml
+++ b/VotingApplication/VotingApplication.Web.Api/Views/Poll/Index.cshtml
@@ -85,7 +85,8 @@
                     <div class="col-md-1"></div>
                     <div class="col-md-10 centered" data-bind="with: votingStrategy">
                         <div><h2>
-                            Winner<span data-bind="text: winners().length > 1 ? 's (Draw)' : ''"></span>: 
+                            <span data-bind="text: $parent.pollExpired() ? 'Winner' : 'Leader'">
+                            </span><span data-bind="text: winners().length > 1 ? 's (Draw)' : ''"></span>: 
                             <span data-bind="text: winners().join(', ')"></span>
                         </h2></div>
 


### PR DESCRIPTION
Fixed bug with result chart checking whether data has changed (must
keep looping since it counts the number of bars).
Show "Leader" rather than "Winner" if poll is still going.