### PR TITLE
Fix 'Site.css' references in SCSS files

### DIFF
--- a/VotingApplication/VotingApplication.Web/App_Start/BundleConfig.cs
+++ b/VotingApplication/VotingApplication.Web/App_Start/BundleConfig.cs
@@ -29,7 +29,6 @@ namespace VotingApplication.Web
 
             StyleBundle votingStyle = new StyleBundle("~/Bundles/VotingStyle");
             votingStyle.Include("~/Content/Scss/Voting.scss");
-            votingStyle.Include("~/Content/Scss/Site.scss");
             votingStyle.Builder = nullBuilder;
             votingStyle.Transforms.Add(styleTransformer);
             votingStyle.Orderer = nullOrderer;
@@ -37,7 +36,6 @@ namespace VotingApplication.Web
 
             StyleBundle createStyle = new StyleBundle("~/Bundles/CreateStyle");
             createStyle.Include("~/Content/Scss/Creation.scss");
-            createStyle.Include("~/Content/Scss/Site.scss");
             createStyle.Builder = nullBuilder;
             createStyle.Transforms.Add(styleTransformer);
             createStyle.Orderer = nullOrderer;

--- a/VotingApplication/VotingApplication.Web/Content/Scss/Creation.scss
+++ b/VotingApplication/VotingApplication.Web/Content/Scss/Creation.scss
@@ -1,4 +1,4 @@
-﻿@import '~/Content/Scss/Site.scss';
+﻿@import 'Site.scss';
 
 $Blue100: #BBDEFB;
 $Blue200: #90CAF9;

--- a/VotingApplication/VotingApplication.Web/Content/Scss/Voting.scss
+++ b/VotingApplication/VotingApplication.Web/Content/Scss/Voting.scss
@@ -1,5 +1,5 @@
 ﻿@import url(http://cdnjs.cloudflare.com/ajax/libs/insightjs/1.3.0/insight.min.css);
-@import '~/Content/Scss/Site.scss';
+@import 'Site.scss';
 
 $Green100: #C8E6C9;
 $Green200: #A5D6A7;


### PR DESCRIPTION
Currently they use a '~' in the path which may be causing problems when
deployed.