### PR TITLE
Display username in place of email

### DIFF
--- a/VotingApplication/VotingApplication.Web/Api/Controllers/ManageController.cs
+++ b/VotingApplication/VotingApplication.Web/Api/Controllers/ManageController.cs
@@ -31,7 +31,8 @@ namespace VotingApplication.Web.Api.Controllers.API_Controllers
             return new TokenRequestModel
             {
                 Email = ballot.Email,
-                TokenGuid = ballot.TokenGuid
+                TokenGuid = ballot.TokenGuid,
+                Name = ballot.VoterName
             };
         }
 

--- a/VotingApplication/VotingApplication.Web/Api/Controllers/ManageController.cs
+++ b/VotingApplication/VotingApplication.Web/Api/Controllers/ManageController.cs
@@ -120,6 +120,7 @@ namespace VotingApplication.Web.Api.Controllers.API_Controllers
                                            .Where(p => p.ManageId == manageId)
                                            .Include(p => p.Options)
                                            .Include(p => p.Ballots)
+                                           .Include(p => p.Ballots.Select(b => b.Votes))
                                            .SingleOrDefault();
 
                 if (poll == null)
@@ -207,6 +208,12 @@ namespace VotingApplication.Web.Api.Controllers.API_Controllers
                 // Clean up tokens which have been removed
                 foreach (Ballot token in redundantTokens)
                 {
+                    foreach (Vote redundantVote in token.Votes.ToList())
+                    {
+                        removedVotes.Add(redundantVote);
+                        token.Votes.Remove(redundantVote);
+                    }
+
                     context.Ballots.Remove(token);
                     poll.Ballots.Remove(token);
                 }

--- a/VotingApplication/VotingApplication.Web/Api/Models/DBViewModels/TokenRequestModel.cs
+++ b/VotingApplication/VotingApplication.Web/Api/Models/DBViewModels/TokenRequestModel.cs
@@ -9,5 +9,6 @@ namespace VotingApplication.Web.Api.Models.DBViewModels
     {
         public Guid? TokenGuid { get; set; }
         public string Email { get; set; }
+        public string Name { get; set; }
     }
 }

--- a/VotingApplication/VotingApplication.Web/Views/Routes/ManageInvitees.cshtml
+++ b/VotingApplication/VotingApplication.Web/Views/Routes/ManageInvitees.cshtml
@@ -6,7 +6,7 @@
 
         <div class="pill-box">
             <div class="invitee-pill" ng-repeat="invitee in poll.Voters">
-                <span class="invitee-pill-text">{{invitee.Email}}</span>
+                <span class="invitee-pill-text">{{invitee.Name || invitee.Email}}</span>
                 <span class="glyphicon glyphicon-remove invitee-pill-delete" ng-click="deleteInvitee(invitee)" aria-hidden="true"></span>
             </div>
         </div>


### PR DESCRIPTION
If the user has already cast a vote with a name, display them with that
name rather than the email address.

This is to help with open polls, where a user can join the poll and gain
a token without having been explicitly invited. Beforehand, this would
display them with a blank email.