### PR TITLE
Fix saving issue in open polls

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/ManageControllerTests.cs
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/ManageControllerTests.cs
@@ -305,6 +305,32 @@ namespace VotingApplication.Web.Api.Tests.Controllers
             CollectionAssert.AreEquivalent(expectedEmails, actualEmails);
         }
 
+        [TestMethod]
+        public void PutWithNullEmailClearsTokenByName()
+        {
+            // Arrange
+            Ballot existingBallot = new Ballot() { Email = null, VoterName = "123", TokenGuid = Guid.NewGuid() };
+            Ballot obsoleteBallot = new Ballot() { Email = null, VoterName = "ABC", TokenGuid = Guid.NewGuid() };
+            TokenRequestModel existingTokenRequest = new TokenRequestModel { Name = "123", EmailSent = true };
+
+            _mainPoll.Ballots = new List<Ballot>() { existingBallot, obsoleteBallot };
+
+            ManagePollUpdateRequest request = new ManagePollUpdateRequest
+            {
+                Name = existingTokenRequest.Name,
+                VotingStrategy = PollType.Basic.ToString(),
+                Voters = new List<TokenRequestModel>() { existingTokenRequest }
+            };
+
+            // Act
+            _controller.Put(_manageMainUUID, request);
+
+            // Assert
+            List<string> expectedVoters = new List<string> { "123" };
+            List<string> actualVoters = _mainPoll.Ballots.Select(s => s.VoterName).ToList<string>();
+            CollectionAssert.AreEquivalent(expectedVoters, actualVoters);
+        }
+
         #endregion
     }
 }

--- a/VotingApplication/VotingApplication.Web/Api/Controllers/ManageController.cs
+++ b/VotingApplication/VotingApplication.Web/Api/Controllers/ManageController.cs
@@ -196,7 +196,10 @@ namespace VotingApplication.Web.Api.Controllers.API_Controllers
                     else
                     {
                         // Don't mark token as redundant if still in use
-                        Ballot ballot = redundantTokens.Find(t => t.Email.Equals(voter.Email, StringComparison.OrdinalIgnoreCase));
+                        Ballot ballot = redundantTokens.Find(t => 
+                            (t.Email == null && voter.Email == null && t.VoterName == voter.Name) ||
+                            (t.Email != null && t.Email.Equals(voter.Email, StringComparison.OrdinalIgnoreCase))
+                        );
                         redundantTokens.Remove(ballot);
                     }
                 }


### PR DESCRIPTION
Some of the voters had a null email, due to voting without an invitation.
This meant that asking for t.Email.Equals() would try calling Equals on
null, which falls over.

We now fall back on the voter name if there is no email. This is not
unique, but we have nothing else identifiable about the user that we can
use.