### PR TITLE
Refactor of AccountDialog controllers

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountLoginControllerTests.js
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountLoginControllerTests.js
@@ -1,0 +1,195 @@
+﻿'use strict';
+
+describe('AccountLoginController', function () {
+
+    beforeEach(module('GVA.Common'));
+
+    var rootScope;
+    var scope;
+    var mockAccountService;
+
+    var loginPromise;
+    var forgotPasswordPromise;
+
+    beforeEach(inject(function ($rootScope, $controller, $q) {
+
+        rootScope = $rootScope;
+        rootScope.error = {};
+
+        scope = $rootScope.$new();
+        scope.closeThisDialog = function () { };
+
+        loginPromise = $q.defer();
+        forgotPasswordPromise = $q.defer();
+
+        mockAccountService = {
+            login: function () { },
+            forgotPassword: function () { }
+        };
+
+        spyOn(mockAccountService, 'login').and.callFake(function () { return loginPromise.promise; });
+        spyOn(mockAccountService, 'forgotPassword').and.callFake(function () { return forgotPasswordPromise.promise; });
+        spyOn(scope, 'closeThisDialog').and.callThrough();
+
+        $controller('AccountLoginController', { $scope: scope, AccountService: mockAccountService });
+    }));
+
+
+    describe('Login Account', function () {
+
+        it('Calls the account service to login', function () {
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+
+            loginPromise.resolve();
+
+            scope.loginAccount(form.email, form.password);
+
+
+            scope.$apply();
+            expect(mockAccountService.login).toHaveBeenCalled();
+        });
+
+        it('Given a successful login call, closes the dialog', function () {
+
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+
+            loginPromise.resolve();
+
+            scope.loginAccount(form.email, form.password);
+
+
+            scope.$apply();
+            expect(scope.closeThisDialog).toHaveBeenCalled();
+        });
+
+        it('Given an unsuccessful register call, displays the error message', function () {
+
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+            var errorMessage = 'Some Error message';
+            rootScope.error.readableMessage = errorMessage;
+
+
+            loginPromise.reject();
+
+            scope.loginAccount(form.email, form.password);
+
+
+            scope.$apply();
+            expect(scope.displayError).toBe(errorMessage);
+        });
+
+        it('Given an unsuccessful register call, removes the error message from the root scope', function () {
+
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+            var errorMessage = 'Some Error message';
+            rootScope.error.readableMessage = errorMessage;
+
+
+            loginPromise.reject();
+
+            scope.loginAccount(form.email, form.password);
+
+
+            scope.$apply();
+            expect(rootScope.error).toBeNull();
+        });
+
+        it('Clears any errors before attempting to login', function () {
+
+            scope.displayError = 'Some Error Message';
+
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+
+            scope.loginAccount(form.email, form.password);
+
+
+            scope.$apply();
+            expect(scope.displayError).toBe(null);
+        });
+    });
+
+    describe('Forgotten Password', function () {
+
+        it('Calls the account service for a forgotten password', function () {
+            var form = {
+                email: 'user@example.com'
+            };
+
+
+            forgotPasswordPromise.resolve();
+
+            scope.forgottenPassword(form);
+
+
+            scope.$apply();
+            expect(mockAccountService.forgotPassword).toHaveBeenCalled();
+        });
+
+        it('Displays an error message when no email is supplied', function () {
+
+            var form = {};
+
+            scope.forgottenPassword(form);
+
+
+            scope.$apply();
+            expect(scope.displayError).toBe('Please supply email address.');
+        });
+
+        it('Given a successful email reset call, closes the dialog', function () {
+
+            var form = {
+                email: 'user@example.com'
+            };
+
+            forgotPasswordPromise.resolve();
+
+
+            scope.forgottenPassword(form);
+
+
+            scope.$apply();
+            expect(scope.closeThisDialog).toHaveBeenCalled();
+        });
+
+        it('Given an unsuccessful email reset call, displays the error message', function () {
+
+            var form = {
+                email: 'user@example.com'
+            };
+
+            var rejection = {
+                Message: 'Some error message'
+            };
+
+            forgotPasswordPromise.reject(rejection);
+
+            scope.forgottenPassword(form);
+
+
+            scope.$apply();
+            expect(scope.displayError).toBe('Some error message');
+        });
+    });
+
+});

--- a/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountRegisterControllerTests.js
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountRegisterControllerTests.js
@@ -1,0 +1,92 @@
+﻿'use strict';
+
+describe('AccountRegisterController', function () {
+
+    beforeEach(module('GVA.Common'));
+
+    var rootScope;
+    var scope;
+    var mockAccountService;
+
+    var registerPromise;
+
+    beforeEach(inject(function ($rootScope, $controller, $q) {
+
+        rootScope = $rootScope;
+        rootScope.error = {};
+
+        scope = $rootScope.$new();
+        scope.closeThisDialog = function () { };
+        scope.ngDialogData = {};
+
+        registerPromise = $q.defer();
+
+        mockAccountService = {
+            registerAccountAndLogin: function () { }
+        };
+
+        spyOn(mockAccountService, 'registerAccountAndLogin').and.callFake(function () { return registerPromise.promise; });
+        spyOn(scope, 'closeThisDialog').and.callThrough();
+
+        $controller('AccountRegisterController', { $scope: scope, AccountService: mockAccountService });
+    }));
+
+
+    describe('Register Account', function () {
+
+        it('Calls the account service to register', function () {
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+
+            registerPromise.resolve();
+
+            scope.registerAccountAndLogin(form.email, form.password);
+
+
+            scope.$apply();
+            expect(mockAccountService.registerAccountAndLogin).toHaveBeenCalled();
+        });
+
+        it('Given a successful register call, closes the dialog', function () {
+
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+
+            registerPromise.resolve();
+
+            scope.registerAccountAndLogin(form.email, form.password);
+
+
+            scope.$apply();
+            expect(scope.closeThisDialog).toHaveBeenCalled();
+        });
+
+        it('Given an unsuccessful register call, displays the error message', function () {
+
+            var form = {
+                email: 'user@example.com',
+                password: 'p@ssword'
+            };
+
+            var errorMessage = 'Some Error message';
+            rootScope.error.readableMessage = errorMessage;
+
+
+            registerPromise.reject();
+
+            scope.registerAccountAndLogin(form.email, form.password);
+
+
+            scope.$apply();
+            expect(scope.displayError).toBe(errorMessage);
+            expect(rootScope.error).toBeNull();
+        });
+    });
+
+});

--- a/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountServiceTests.js
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountServiceTests.js
@@ -142,6 +142,70 @@ describe('AccountServiceTests', function () {
 
     });
 
+    describe('Login', function () {
 
+        it('Calls api to get a token', function () {
+            httpBackend
+                .expect('POST', '/Token')
+                .respond(200, tokenResponse);
+
+            accountService.login(formData.email, formData.password);
+
+            httpBackend.flush();
+
+            httpBackend.verifyNoOutstandingExpectation();
+            httpBackend.verifyNoOutstandingRequest();
+
+            // http://stackoverflow.com/questions/27016235/angular-js-unit-testing-httpbackend-spec-has-no-expectations
+            expect('Suppress SPEC HAS NO EXPECTATIONS').toBeDefined();
+        });
+
+        it('Given an unsuccessful token call, rejects promise', inject(function ($rootScope) {
+
+
+            httpBackend
+                .expect('POST', '/Token')
+                .respond(400);
+
+            var failed = false;
+
+            accountService.login(formData.email, formData.password)
+                .catch(function () { failed = true; });
+
+            httpBackend.flush();
+
+            $rootScope.$apply();
+            expect(failed).toBe(true);
+        }));
+
+        it('Given a successful token call, saves the token in service account property', function () {
+            httpBackend
+                .when('POST', '/Token')
+                .respond(200, tokenResponse);
+
+            accountService.login(formData.email, formData.password);
+
+            httpBackend.flush();
+
+            expect(accountService.account).toBeDefined();
+            expect(accountService.account.email).toBe('user@example.com');
+            expect(accountService.account.token).toBe('A33CE1DB-67C1-47F2-832A-8CC3F8155814');
+        });
+
+        it('Given a successful token call, updates account and notifies observers', function () {
+            httpBackend
+                .when('POST', '/Token')
+                .respond(200, tokenResponse);
+
+            var observerNotified = false;
+            accountService.registerAccountObserver(function () { observerNotified = true; });
+
+            accountService.login(formData.email, formData.password);
+
+            httpBackend.flush();
+
+            expect(observerNotified).toBe(true);
+        });
+    });
 
 });

--- a/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountServiceTests.js
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Scripts/AccountServiceTests.js
@@ -1,0 +1,147 @@
+﻿'use strict';
+
+describe('AccountServiceTests', function () {
+
+    beforeEach(module('GVA.Common'));
+
+    var accountService;
+    var httpBackend;
+
+    var formData = {
+        email: 'user@example.com',
+        password: 'letmein'
+    };
+
+    var tokenResponse = { access_token: 'A33CE1DB-67C1-47F2-832A-8CC3F8155814' };
+
+    beforeEach(inject(function (AccountService, $httpBackend) {
+        accountService = AccountService;
+        httpBackend = $httpBackend;
+    }));
+
+    describe('Register Account And Login', function () {
+
+        it('Calls api to register', function () {
+
+            httpBackend
+                .expect('POST', '/api/Account/Register')
+                .respond(200);
+
+            httpBackend
+                .when('POST', '/Token')
+                .respond(200, tokenResponse);
+
+            accountService.registerAccountAndLogin(formData.email, formData.password);
+
+            httpBackend.flush();
+
+            httpBackend.verifyNoOutstandingExpectation();
+            httpBackend.verifyNoOutstandingRequest();
+
+            // http://stackoverflow.com/questions/27016235/angular-js-unit-testing-httpbackend-spec-has-no-expectations
+            expect('Suppress SPEC HAS NO EXPECTATIONS').toBeDefined();
+        });
+
+        it('Given an unsuccessful register call, rejects promise', inject(function ($rootScope) {
+
+            httpBackend
+                .when('POST', '/api/Account/Register')
+                .respond(400);
+
+            var failed = false;
+
+            accountService.registerAccountAndLogin(formData.email, formData.password)
+                .catch(function () { failed = true; });
+
+            httpBackend.flush();
+
+            $rootScope.$apply();
+            expect(failed).toBe(true);
+        }));
+
+        it('Given a successful register call, calls api to get a token', function () {
+
+            httpBackend
+                .when('POST', '/api/Account/Register')
+                .respond(200);
+
+            httpBackend
+                .expect('POST', '/Token')
+                .respond(200, tokenResponse);
+
+            accountService.registerAccountAndLogin(formData.email, formData.password);
+
+            httpBackend.flush();
+
+            httpBackend.verifyNoOutstandingExpectation();
+            httpBackend.verifyNoOutstandingRequest();
+
+            // http://stackoverflow.com/questions/27016235/angular-js-unit-testing-httpbackend-spec-has-no-expectations
+            expect('Suppress SPEC HAS NO EXPECTATIONS').toBeDefined();
+        });
+
+        it('Given an unsuccessful token call, rejects promise', inject(function ($rootScope) {
+
+            httpBackend
+                .when('POST', '/api/Account/Register')
+                .respond(200);
+
+            httpBackend
+                .expect('POST', '/Token')
+                .respond(400);
+
+            var failed = false;
+
+            accountService.registerAccountAndLogin(formData.email, formData.password)
+                .catch(function () { failed = true; });
+
+            httpBackend.flush();
+
+            $rootScope.$apply();
+            expect(failed).toBe(true);
+        }));
+
+        it('Given a successful token call, saves the token in service account property', function () {
+
+            httpBackend
+                .when('POST', '/api/Account/Register')
+                .respond(200);
+
+            httpBackend
+                .when('POST', '/Token')
+                .respond(200, tokenResponse);
+
+            accountService.registerAccountAndLogin(formData.email, formData.password);
+
+            httpBackend.flush();
+
+            expect(accountService.account).toBeDefined();
+            expect(accountService.account.email).toBe('user@example.com');
+            expect(accountService.account.token).toBe('A33CE1DB-67C1-47F2-832A-8CC3F8155814');
+        });
+
+        it('Given a successful token call, updates account and notifies observers', function () {
+
+            httpBackend
+                .when('POST', '/api/Account/Register')
+                .respond(200);
+
+            httpBackend
+                .when('POST', '/Token')
+                .respond(200, tokenResponse);
+
+            var observerNotified = false;
+            accountService.registerAccountObserver(function () { observerNotified = true; });
+
+            accountService.registerAccountAndLogin(formData.email, formData.password);
+
+            httpBackend.flush();
+
+            expect(observerNotified).toBe(true);
+        });
+
+    });
+
+
+
+});

--- a/VotingApplication/VotingApplication.Web.Api.Tests/VotingApplication.Web.Api.Tests.csproj
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/VotingApplication.Web.Api.Tests.csproj
@@ -147,6 +147,8 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Scripts\AccountRegisterControllerTests.js" />
+    <Content Include="Scripts\AccountServiceTests.js" />
     <Content Include="Scripts\HomepageControllerTests.js" />
     <Content Include="Scripts\Lib\angular-mocks.js" />
     <Content Include="Scripts\ManageServiceTests.js" />

--- a/VotingApplication/VotingApplication.Web.Api.Tests/VotingApplication.Web.Api.Tests.csproj
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/VotingApplication.Web.Api.Tests.csproj
@@ -147,6 +147,7 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Scripts\AccountLoginControllerTests.js" />
     <Content Include="Scripts\AccountRegisterControllerTests.js" />
     <Content Include="Scripts\AccountServiceTests.js" />
     <Content Include="Scripts\HomepageControllerTests.js" />

--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountLoginController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountLoginController.js
@@ -1,5 +1,4 @@
 ﻿/// <reference path="../Services/AccountService.js" />
-/// <reference path="../Services/ErrorService.js" />
 (function () {
     'use strict';
 
@@ -23,7 +22,7 @@
         }
 
         function displayErrorMessage() {
-            $scope.displayError = $rootScope.error.readableMessage;
+            displayError($rootScope.error.readableMessage);
             $rootScope.error = null;
         }
 
@@ -45,11 +44,11 @@
         }
 
         function clearError() {
-            $scope.errorMessage = '';
+            $scope.displayError = null;
         }
 
         function displayError(errorMessage) {
-            $scope.errorMessage = errorMessage;
+            $scope.displayError = errorMessage;
         }
 
 

--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountLoginController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountLoginController.js
@@ -22,7 +22,7 @@
         }
 
         function displayErrorMessage() {
-            displayError($rootScope.error.readableMessage);
+            showError($rootScope.error.readableMessage);
             $rootScope.error = null;
         }
 
@@ -30,12 +30,12 @@
             clearError();
 
             if (form.email === undefined) {
-                displayError('Please supply email address.');
+                showError('Please supply email address.');
             }
             else {
                 AccountService.forgotPassword(form.email)
                     .then(closeDialog)
-                    .catch(function (data) { displayError(data.Message || data.error_description); });
+                    .catch(function (data) { showError(data.Message || data.error_description); });
             }
         }
 
@@ -47,7 +47,7 @@
             $scope.displayError = null;
         }
 
-        function displayError(errorMessage) {
+        function showError(errorMessage) {
             $scope.displayError = errorMessage;
         }
 

--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountLoginController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountLoginController.js
@@ -13,60 +13,46 @@
 
         $scope.loginAccount = loginAccount;
         $scope.forgottenPassword = forgottenPassword;
-        
+
         function loginAccount(form) {
             clearError();
 
-            // Can this not be turned into a promise?
-            AccountService.getAccessToken(form.email, form.password).success(function (data) {
-                loginCallback(form.email, data);
-            })
-            .error(function (data, status) {
-                loginFailureCallback(form, data, status);
-            });
-        }
-        
-        function forgottenPassword(form) {
-            clearError();
-            
-            if (form.email === undefined) {
-                displayError('Please supply email address.');
-                return;
-            }
-
-            AccountService.forgotPassword(form.email).success(function () {
-                $scope.closeThisDialog();
-
-                if ($scope.ngDialogData.callback) {
-                    $scope.ngDialogData.callback();
-                }
-            })
-            .error(function (data) {
-                displayError(data.Message || data.error_description);
-            });
+            AccountService.login(form.email, form.password)
+                .then(closeDialog)
+                .catch(displayErrorMessage);
         }
 
-        function loginCallback(email, data) {
-            AccountService.setAccount(data.access_token, email);
-
-            $scope.closeThisDialog();
-            if ($scope.ngDialogData.callback) {
-                $scope.ngDialogData.callback();
-            }
-        }
-
-        function loginFailureCallback() {
+        function displayErrorMessage() {
             $scope.displayError = $rootScope.error.readableMessage;
             $rootScope.error = null;
+        }
+
+        function forgottenPassword(form) {
+            clearError();
+
+            if (form.email === undefined) {
+                displayError('Please supply email address.');
+            }
+            else {
+                AccountService.forgotPassword(form.email)
+                    .then(closeDialog)
+                    .catch(function (data) { displayError(data.Message || data.error_description); });
+            }
+        }
+
+        function closeDialog() {
+            $scope.closeThisDialog();
+        }
+
+        function clearError() {
+            $scope.errorMessage = '';
         }
 
         function displayError(errorMessage) {
             $scope.errorMessage = errorMessage;
         }
 
-        function clearError() {
-            $scope.errorMessage = '';
-        }
+
     }
 
 })();

--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountRegisterController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AccountRegisterController.js
@@ -11,24 +11,22 @@
 
     function AccountRegisterController($scope, $rootScope, AccountService) {
 
-        $scope.registerAccount = function (form) {
-            AccountService.register(form.email, form.password).success(function () {
-                return AccountService.getAccessToken(form.email, form.password);
-            }).success(function (data) {
-                AccountService.setAccount(data.access_token, form.email);
+        $scope.registerAccountAndLogin = registerAccount;
 
+        function registerAccount(form) {
+
+            AccountService.registerAccountAndLogin(form.email, form.password)
+                .then(closeDialog)
+                .catch(displayErrorMessage);
+
+            function closeDialog() {
                 $scope.closeThisDialog();
-                if ($scope.ngDialogData.callback) {
-                    $scope.ngDialogData.callback();
-                }
-            }).error(loginFailureCallback);
+            }
 
-            function loginFailureCallback() {
+            function displayErrorMessage() {
                 $scope.displayError = $rootScope.error.readableMessage;
                 $rootScope.error = null;
             }
-        };
-
+        }
     }
-
 })();

--- a/VotingApplication/VotingApplication.Web/Scripts/Services/AccountService.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Services/AccountService.js
@@ -5,9 +5,9 @@
         .module('GVA.Common')
         .factory('AccountService', AccountService);
 
-    AccountService.$inject = ['$localStorage', '$http', 'ngDialog'];
+    AccountService.$inject = ['$localStorage', '$http', 'ngDialog', '$q'];
 
-    function AccountService($localStorage, $http, ngDialog) {
+    function AccountService($localStorage, $http, ngDialog, $q) {
 
         var self = this;
 
@@ -25,12 +25,7 @@
             observerCallbacks.push(callback);
         };
 
-        self.setAccount = function (token, email) {
-            var account = { 'token': token, 'email': email };
-            self.account = account;
-            $localStorage.account = account;
-            notifyObservers();
-        };
+        self.setAccount = setAccount;
 
         self.clearAccount = function () {
             self.account = null;
@@ -38,7 +33,33 @@
             notifyObservers();
         };
 
-        self.getAccessToken = function (email, password) {
+        self.getAccessToken = getAccessToken;
+
+        self.registerAccountAndLogin = function (email, password) {
+            var deferred = $q.defer();
+
+            register(email, password)
+                .then(function () { return getAccessToken(email, password); })
+                .then(function (response) { setAccount(response.data.access_token, email); })
+                .then(function () { deferred.resolve(); })
+                .catch(function () { deferred.reject(); });
+
+            return deferred.promise;
+        };
+
+        function register(email, password) {
+            return $http({
+                method: 'POST',
+                url: '/api/Account/Register',
+                contentType: 'application/json; charset=utf-8',
+                data: JSON.stringify({
+                    Email: email,
+                    Password: password
+                })
+            });
+        }
+
+        function getAccessToken(email, password) {
             return $http({
                 method: 'POST',
                 url: '/Token',
@@ -58,19 +79,15 @@
                     password: password
                 }
             });
-        };
+        }
 
-        self.register = function (email, password) {
-            return $http({
-                method: 'POST',
-                url: '/api/Account/Register',
-                contentType: 'application/json; charset=utf-8',
-                data: JSON.stringify({
-                    Email: email,
-                    Password: password
-                })
-            });
-        };
+        function setAccount(token, email) {
+            var account = { 'token': token, 'email': email };
+            self.account = account;
+            $localStorage.account = account;
+
+            notifyObservers();
+        }
 
         self.forgotPassword = function (email) {
             return $http({
@@ -106,12 +123,11 @@
             });
         };
 
-        self.openRegisterDialog = function (scope, callback) {
+        self.openRegisterDialog = function (scope) {
             ngDialog.open({
                 template: '../Routes/AccountRegister',
                 controller: 'AccountRegisterController',
-                'scope': scope,
-                data: { 'callback': callback }
+                'scope': scope
             });
         };
 

--- a/VotingApplication/VotingApplication.Web/Scripts/Services/AccountService.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Services/AccountService.js
@@ -35,16 +35,7 @@
 
         self.registerAccountAndLogin = registerAccountAndLogin;
 
-        self.forgotPassword = function (email) {
-            return $http({
-                method: 'POST',
-                url: '/api/Account/ForgotPassword',
-                contentType: 'application/json; charset=utf-8',
-                data: JSON.stringify({
-                    Email: email
-                })
-            });
-        };
+        self.forgotPassword = forgotPassword;
 
         self.resetPassword = function (email, code, password, confirmPassword) {
             return $http({
@@ -60,23 +51,13 @@
             });
         };
 
-        self.openLoginDialog = function (scope) {
-            ngDialog.open({
-                template: '../Routes/AccountLogin',
-                controller: 'AccountLoginController',
-                'scope': scope
-            });
-        };
+        self.openLoginDialog = openLoginDialog;
 
-        self.openRegisterDialog = function (scope) {
-            ngDialog.open({
-                template: '../Routes/AccountRegister',
-                controller: 'AccountRegisterController',
-                'scope': scope
-            });
-        };
+        self.openRegisterDialog = openRegisterDialog;
 
         return self;
+
+
 
         function login(email, password) {
             var deferred = $q.defer();
@@ -87,6 +68,17 @@
                 .catch(function () { deferred.reject(); });
 
             return deferred.promise;
+        }
+
+        function forgotPassword(email) {
+            return $http({
+                method: 'POST',
+                url: '/api/Account/ForgotPassword',
+                contentType: 'application/json; charset=utf-8',
+                data: JSON.stringify({
+                    Email: email
+                })
+            });
         }
 
         function registerAccountAndLogin(email, password) {
@@ -134,6 +126,22 @@
             $localStorage.account = account;
 
             notifyObservers();
+        }
+
+        function openLoginDialog(scope) {
+            ngDialog.open({
+                template: '../Routes/AccountLogin',
+                controller: 'AccountLoginController',
+                'scope': scope
+            });
+        }
+
+        function openRegisterDialog(scope) {
+            ngDialog.open({
+                template: '../Routes/AccountRegister',
+                controller: 'AccountRegisterController',
+                'scope': scope
+            });
         }
     }
 })();

--- a/VotingApplication/VotingApplication.Web/Scripts/Services/AccountService.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Services/AccountService.js
@@ -25,27 +25,74 @@
             observerCallbacks.push(callback);
         };
 
-        self.setAccount = setAccount;
-
         self.clearAccount = function () {
             self.account = null;
             delete $localStorage.account;
             notifyObservers();
         };
 
-        self.getAccessToken = getAccessToken;
+        self.login = login;
 
-        self.registerAccountAndLogin = function (email, password) {
+        self.registerAccountAndLogin = registerAccountAndLogin;
+
+        self.forgotPassword = function (email) {
+            return $http({
+                method: 'POST',
+                url: '/api/Account/ForgotPassword',
+                contentType: 'application/json; charset=utf-8',
+                data: JSON.stringify({
+                    Email: email
+                })
+            });
+        };
+
+        self.resetPassword = function (email, code, password, confirmPassword) {
+            return $http({
+                method: 'POST',
+                url: '/api/Account/ResetPassword',
+                contentType: 'application/json; charset=utf-8',
+                data: JSON.stringify({
+                    Email: email,
+                    Code: code,
+                    Password: password,
+                    ConfirmPassword: confirmPassword
+                })
+            });
+        };
+
+        self.openLoginDialog = function (scope) {
+            ngDialog.open({
+                template: '../Routes/AccountLogin',
+                controller: 'AccountLoginController',
+                'scope': scope
+            });
+        };
+
+        self.openRegisterDialog = function (scope) {
+            ngDialog.open({
+                template: '../Routes/AccountRegister',
+                controller: 'AccountRegisterController',
+                'scope': scope
+            });
+        };
+
+        return self;
+
+        function login(email, password) {
             var deferred = $q.defer();
 
-            register(email, password)
-                .then(function () { return getAccessToken(email, password); })
+            getAccessToken(email, password)
                 .then(function (response) { setAccount(response.data.access_token, email); })
                 .then(function () { deferred.resolve(); })
                 .catch(function () { deferred.reject(); });
 
             return deferred.promise;
-        };
+        }
+
+        function registerAccountAndLogin(email, password) {
+            return register(email, password)
+                .then(function () { return login(email, password); });
+        }
 
         function register(email, password) {
             return $http({
@@ -88,49 +135,5 @@
 
             notifyObservers();
         }
-
-        self.forgotPassword = function (email) {
-            return $http({
-                method: 'POST',
-                url: '/api/Account/ForgotPassword',
-                contentType: 'application/json; charset=utf-8',
-                data: JSON.stringify({
-                    Email: email
-                })
-            });
-        };
-
-        self.resetPassword = function (email, code, password, confirmPassword) {
-            return $http({
-                method: 'POST',
-                url: '/api/Account/ResetPassword',
-                contentType: 'application/json; charset=utf-8',
-                data: JSON.stringify({
-                    Email: email,
-                    Code: code,
-                    Password: password,
-                    ConfirmPassword: confirmPassword
-                })
-            });
-        };
-
-        self.openLoginDialog = function (scope, callback) {
-            ngDialog.open({
-                template: '../Routes/AccountLogin',
-                controller: 'AccountLoginController',
-                'scope': scope,
-                data: { 'callback': callback }
-            });
-        };
-
-        self.openRegisterDialog = function (scope) {
-            ngDialog.open({
-                template: '../Routes/AccountRegister',
-                controller: 'AccountRegisterController',
-                'scope': scope
-            });
-        };
-
-        return self;
     }
 })();

--- a/VotingApplication/VotingApplication.Web/Scripts/Services/ErrorService.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Services/ErrorService.js
@@ -27,7 +27,7 @@
             form.errors = {};
 
             for (var modelError in modelState) {
-                if (modelState.hasOwnProperty(modelError) && modelError !== undefined) {
+                if (modelState.hasOwnProperty(modelError)) {
                     var key = modelError.replace('model.', '').toLowerCase();
 
                     if (form.hasOwnProperty(key)) {

--- a/VotingApplication/VotingApplication.Web/Views/Routes/AccountRegister.cshtml
+++ b/VotingApplication/VotingApplication.Web/Views/Routes/AccountRegister.cshtml
@@ -1,5 +1,5 @@
 ﻿<div class="account-register dialog-content centered">
-    <form name="registerForm" ng-submit="registerAccount(registerForm)">
+    <form name="registerForm" ng-submit="registerAccountAndLogin(registerForm)">
         <div class="form-section-block centered">
             <label for="email">Email</label>
             <input autofocus required class="form-input" type="email" id="email" placeholder="user@example.com" ng-model="registerForm.email">


### PR DESCRIPTION
Being moving front end to using promises.
Refactor of AccountLoginController and AccountRegisterController to push logic into AccountService.

Fixed two bugs:
+ Registering a new account failed to login immediately after registration.
+ Not all errors were displayed on the login dialog.