### PR TITLE
Fix Voter add option not showing for Basic Vote

### DIFF
--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/BasicVoteController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/BasicVoteController.js
@@ -32,7 +32,7 @@
             $scope.$watch('poll', function () {
                 if ($scope.poll) {
                     $scope.options = $scope.poll.Options;
-                    $scope.optionAddingAllowed = $scope.poll.OptionAddingAllowed;
+                    $scope.optionAddingAllowed = $scope.poll.OptionAdding;
                 }
             });
 


### PR DESCRIPTION
BasicVoteController was looking at an undefined value on the poll
(OptionAddingAllowed), rather than the correct one (OptionAdding).