### PR TITLE
Fix "The ExpiryDate field is required"

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/ManageExpiryControllerTests.cs
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/Controllers/ManageExpiryControllerTests.cs
@@ -36,6 +36,7 @@ namespace VotingApplication.Web.Api.Tests.Controllers
             [TestMethod]
             public void NullExpiry_SetsExpiryToNull()
             {
+                // Arrange
                 IDbSet<Poll> existingPolls = DbSetTestHelper.CreateMockDbSet<Poll>();
                 Poll existingPoll = CreatePoll();
                 existingPolls.Add(existingPoll);
@@ -44,9 +45,12 @@ namespace VotingApplication.Web.Api.Tests.Controllers
                 ManagePollExpiryRequest request = new ManagePollExpiryRequest { };
 
                 ManageExpiryController controller = CreateManageExpiryController(contextFactory);
+                controller.Validate(request);
 
+                // Act
                 controller.Put(PollManageGuid, request);
 
+                // Assert
                 Assert.IsNull(existingPoll.ExpiryDate);
             }
 

--- a/VotingApplication/VotingApplication.Web/Api/Models/DBViewModels/ManagePollExpiryRequest.cs
+++ b/VotingApplication/VotingApplication.Web/Api/Models/DBViewModels/ManagePollExpiryRequest.cs
@@ -5,7 +5,6 @@ namespace VotingApplication.Web.Api.Models.DBViewModels
 {
     public class ManagePollExpiryRequest
     {
-        [Required]
         public DateTime? ExpiryDate { get; set; }
     }
 }


### PR DESCRIPTION
Good news everyone! I've found how to set the ModelState.isValid in a
unit test, without having to just say "isValid = false".

"controller.Validate(request)" will parse the request against the model,
and check any [Required] and [Range(0,10)] type tags, then set
ModelState.isValid automatically!