### PR TITLE
Update Chutzpah

### DIFF
--- a/VotingApplication/VotingApplication.Web.Api.Tests/packages.config
+++ b/VotingApplication/VotingApplication.Web.Api.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chutzpah" version="3.2.6" />
+  <package id="Chutzpah" version="4.0.1" />
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
   <package id="FakeDbSet" version="1.4.0.0" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />


### PR DESCRIPTION
Update Chutzpah from 3.2.6 to 4.0.1.

This keeps Appveyor in line with the VS extension, and updates the internal jasmine version from 2.0 to 2.1.3