### PR TITLE
Force logout if token is invalid

### DIFF
--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/RegisteredDashboardController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/RegisteredDashboardController.js
@@ -13,7 +13,8 @@
 
     function RegisteredDashboardController($scope, AccountService, PollService, RoutingService, TokenService) {
 
-        $scope.account = AccountService.account;
+        var UNAUTHORISED = 401;
+
         $scope.createPoll = createNewPoll;
         $scope.getUserPolls = getUserPolls;
         $scope.manageUrl = manageUrl;
@@ -25,10 +26,6 @@
 
 
         function activate() {
-            AccountService.registerAccountObserver(function () {
-                $scope.account = AccountService.account;
-            });
-
             getUserPolls();
         }
 
@@ -48,6 +45,11 @@
             PollService.getUserPolls()
                 .then(function (response) {
                     $scope.userPolls = response.data;
+                })
+                .catch(function (response) {
+                    if (response.status === UNAUTHORISED) {
+                        AccountService.clearAccount();
+                    }
                 });
         }
 


### PR DESCRIPTION
If the call to get the polls for the registered dashboard fails then
remove the local auth token. The observer function will cause the homepage
to switch the dashboard over to the unregistered dashboard.

Trying to try this all together to show the login dialog if it fails just
wouldn't work.

This fixes VA-391 and VA-406.