### PR TITLE
Fix VA-422 choice adding validation in ie

### DIFF
--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddOptionDialogController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddOptionDialogController.js
@@ -25,11 +25,17 @@
                 Description: form.description,
                 ChoiceNumber: null
             };
+            
+            $scope.choices.push(newChoice);
+
+            var formElement = angular.element(document.querySelector('form'));
+            formElement.attr('novalidate', '');
 
             form.name = null;
             form.description = null;
+            form.reset();
 
-            $scope.choices.push(newChoice);
+            formElement.removeAttr('novalidate', '');
         }
 
         function addChoiceAndClose(form) {

--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddOptionDialogController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddOptionDialogController.js
@@ -28,7 +28,7 @@
             
             $scope.choices.push(newChoice);
 
-            var formElement = angular.element(document.querySelector('form'));
+            var formElement = angular.element(document.querySelector('#addChoiceDialog-Form'));
             formElement.attr('novalidate', '');
 
             form.name = null;

--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddVoterOptionDialogController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddVoterOptionDialogController.js
@@ -33,7 +33,7 @@
             VoteService.addVoterChoice($scope.ngDialogData.pollId, newVoterChoice)
                 .then($scope.notifyChoiceAdded);
 
-            var formElement = angular.element(document.querySelector('form'));
+            var formElement = angular.element(document.querySelector('#addChoiceDialog-Form'));
             formElement.attr('novalidate', '');
 
             form.name = null;

--- a/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddVoterOptionDialogController.js
+++ b/VotingApplication/VotingApplication.Web/Scripts/Controllers/AddVoterOptionDialogController.js
@@ -32,6 +32,15 @@
 
             VoteService.addVoterChoice($scope.ngDialogData.pollId, newVoterChoice)
                 .then($scope.notifyChoiceAdded);
+
+            var formElement = angular.element(document.querySelector('form'));
+            formElement.attr('novalidate', '');
+
+            form.name = null;
+            form.description = null;
+            form.reset();
+
+            formElement.removeAttr('novalidate', '');
         }
 
         function addChoiceAndClose(form) {

--- a/VotingApplication/VotingApplication.Web/Views/Routes/AddChoiceDialog.cshtml
+++ b/VotingApplication/VotingApplication.Web/Views/Routes/AddChoiceDialog.cshtml
@@ -1,5 +1,5 @@
 ﻿﻿<div class="dialog-box-small dialog-content centered">
-    <form name="addChoiceForm">
+    <form id="addChoiceDialog-Form" name="addChoiceForm">
         <h2>New Choice</h2>
         <div class="form-section-block centered">
             <label for="name">Name</label>


### PR DESCRIPTION
Fix validation error when adding a choice in IE.
Adding a choice with "Add another" checked now doesn't claim the empty
input is required on IE.
Also fixed the Voter choice adding dialog, as checking "Add another"
wasn't clearing out the existing text.