### PR TITLE
Return failures when re-registering

### DIFF
--- a/VotingApplication/VotingApplication.Web/Api/Controllers/AccountController.cs
+++ b/VotingApplication/VotingApplication.Web/Api/Controllers/AccountController.cs
@@ -430,16 +430,16 @@ namespace VotingApplication.Web.Api.Controllers
 
             IdentityResult identityResult = await UserManager.CreateAsync(user, model.Password);
 
-            string code = await UserManager.GenerateEmailConfirmationTokenAsync(user.Id);
-
-            _correspondenceService.SendConfirmation(user.Email, code);
-
             var createResult = GetErrorResult(identityResult);
 
             if (createResult != null)
             {
                 return createResult;
             }
+
+            string code = await UserManager.GenerateEmailConfirmationTokenAsync(user.Id);
+
+            _correspondenceService.SendConfirmation(user.Email, code);
 
             _metricHandler.HandleRegisterEvent(user.UserName);
 


### PR DESCRIPTION
Return the correct failure when attempting to register with an existing
email, rather than a generic 500.
Not handled on front-end, however.