### PR TITLE
E2E test fixes

### DIFF
--- a/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
@@ -1,21 +1,16 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
 using Protractor;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using VotingApplication.Data.Model;
 using VotingApplication.Web.Tests.E2E.Helpers;
-using VotingApplication.Web.Tests.E2E.Helpers.Clearers;
 
 namespace VotingApplication.Web.Tests.E2E
 {
     public class BasicPollTests
     {
-        private const string ChromeDriverDir = @"..\..\";
-        private const string SiteBaseUri = @"http://localhost:64205/";
-
         [TestClass]
         public class DefaultPollConfiguration : E2ETest
         {
@@ -418,25 +413,96 @@ namespace VotingApplication.Web.Tests.E2E
         }
 
         [TestClass]
-        public class ChoiceAddingPollConfiguration
+        public class ChoiceAddingTests : E2ETest
         {
-            private static ITestVotingContext _context;
-            private static Poll _choiceAddingBasicPoll;
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
-            private IWebDriver _driver;
+            private static readonly string PollVoteUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
-            [ClassInitialize]
-            public static void ClassInitialise(TestContext testContext)
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void ChoiceAddingPoll_UserChoiceInputVisible()
             {
-                _context = new TestVotingContext();
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateChoiceAddingPoll(context);
 
-                List<Choice> testPollChoices = new List<Choice>() {
-                new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
-                new Choice(){ Name = "Test Choice 2", Description = "Test Description 2" }};
+                        GoToUrl(driver, PollVoteUrl);
 
-                // Open, Named voters, No Choice Adding, Shown Results
-                _choiceAddingBasicPoll = new Poll()
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+
+                        Assert.IsTrue(addChoiceInput.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NonChoiceAddingPoll_UserChoiceInputNotVisible()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        Poll poll = CreateChoiceAddingPoll(context);
+                        poll.ChoiceAdding = false;
+                        context.SaveChanges();
+
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+
+                        Assert.IsFalse(addChoiceInput.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void Add_AddsChoice()
+            {
+                const string newChoiceName = "NEW CHOICE";
+
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        Poll poll = CreateChoiceAddingPoll(context);
+
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+                        addChoiceInput.SendKeys(newChoiceName);
+
+                        IWebElement formButton = FindElementById(driver, "add-user-choice-button");
+                        formButton.Click();
+
+                        IReadOnlyCollection<IWebElement> choiceNames = driver.FindElements(NgBy.Binding("choice.Name"));
+
+                        Assert.AreEqual(poll.Choices.Count + 1, choiceNames.Count);
+                        Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
+
+                        // Refresh to ensure the new choice was stored in DB
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IReadOnlyCollection<IWebElement> choiceNamesAfterRefresh = driver.FindElements(NgBy.Binding("choice.Name"));
+
+                        Assert.AreEqual(poll.Choices.Count + 1, choiceNamesAfterRefresh.Count);
+                        Assert.AreEqual(newChoiceName, choiceNamesAfterRefresh.Last().Text);
+                    }
+                }
+            }
+
+            public static Poll CreateChoiceAddingPoll(TestVotingContext testContext)
+            {
+                var testPollChoices = new List<Choice>() 
+                {
+                    new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
+                };
+
+                // Open, Anonymous, Choice Adding, Shown Results
+                var choiceAddingBasicPoll = new Poll()
                 {
                     UUID = PollGuid,
                     PollType = PollType.Basic,
@@ -450,107 +516,10 @@ namespace VotingApplication.Web.Tests.E2E
                     ElectionMode = false
                 };
 
-                _context.Polls.Add(_choiceAddingBasicPoll);
-                _context.SaveChanges();
-            }
+                testContext.Polls.Add(choiceAddingBasicPoll);
+                testContext.SaveChanges();
 
-            [ClassCleanup]
-            public static void ClassCleanup()
-            {
-                PollClearer pollTearDown = new PollClearer(_context);
-                pollTearDown.ClearPoll(_choiceAddingBasicPoll);
-
-                _context.Dispose();
-            }
-
-            [TestInitialize]
-            public virtual void TestInitialise()
-            {
-                _driver = new NgWebDriver(new ChromeDriver(ChromeDriverDir));
-                _driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
-                _driver.Manage().Timeouts().SetPageLoadTimeout(TimeSpan.FromSeconds(10));
-            }
-
-            [TestCleanup]
-            public void TestCleanUp()
-            {
-                _driver.Dispose();
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingPoll_ProvidesLinkForAddingChoices()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-
-                Assert.IsTrue(addChoiceLink.IsVisible());
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingLink_PromptsForChoiceDetails()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                Assert.AreEqual(PollUrl, _driver.Url);
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-                Assert.IsTrue(formName.IsVisible());
-                Assert.AreEqual(String.Empty, formName.Text);
-
-                IWebElement formDescription = _driver.FindElement(NgBy.Model("addChoiceForm.description"));
-                Assert.IsTrue(formDescription.IsVisible());
-                Assert.AreEqual(String.Empty, formDescription.Text);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingPrompt_AcceptsValidName()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-                IWebElement addButton = _driver.FindElement(By.Id("add-button"));
-
-                Assert.IsTrue(addButton.IsVisible());
-                Assert.IsFalse(addButton.Enabled);
-
-                formName.SendKeys("New Choice");
-
-                Assert.IsTrue(addButton.Enabled);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingSubmission_AddsChoice()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-                const string newChoiceName = "New Choice";
-                formName.SendKeys(newChoiceName);
-
-                IWebElement formButton = _driver.FindElement(By.Id("add-button"));
-                formButton.Click();
-
-                IReadOnlyCollection<IWebElement> choiceNames = _driver.FindElements(NgBy.Binding("choice.Name"));
-
-                Assert.AreEqual(_choiceAddingBasicPoll.Choices.Count + 1, choiceNames.Count);
-                Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
-
-                // Refresh to ensure the new choice was stored in DB
-                _driver.Navigate().GoToUrl(PollUrl);
-
-                choiceNames = _driver.FindElements(NgBy.Binding("choice.Name"));
-
-                Assert.AreEqual(_choiceAddingBasicPoll.Choices.Count + 1, choiceNames.Count);
-                Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
-
-                _choiceAddingBasicPoll.Choices.Remove(_choiceAddingBasicPoll.Choices.Last());
-                _context.SaveChanges();
+                return choiceAddingBasicPoll;
             }
         }
 

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
@@ -101,8 +101,9 @@ namespace VotingApplication.Web.Tests.E2E
                 }
             }
 
+            [Ignore]
             [TestMethod]
-            [TestCategory("E2E")]
+            [TestCategory("E2ERewrite")]
             public void ClearVote_RemovesVote()
             {
                 using (IWebDriver driver = Driver)
@@ -134,7 +135,7 @@ namespace VotingApplication.Web.Tests.E2E
             {
                 var testPollChoices = new List<Choice>() 
                 {
-                    new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
+                    new Choice(){ Name = "TEST CHOICE 1", Description = "Test Description 1" },
                 };
 
                 // Open, Anonymous, No Choice Adding, Shown Results
@@ -220,8 +221,8 @@ namespace VotingApplication.Web.Tests.E2E
             {
                 List<Choice> testPollChoices = new List<Choice>
                 {
-                    new Choice() { Name = "Test Choice 1", Description = "Test Description 1"},
-                    new Choice() { Name = "Test Choice 2", Description = "Test Description 2"}
+                    new Choice() { Name = "TEST CHOICE 1", Description = "Test Description 1"},
+                    new Choice() { Name = "TEST CHOICE 2", Description = "Test Description 2"}
                 };
 
 

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
@@ -20,7 +20,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class DefaultPollConfiguration : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -46,94 +46,6 @@ namespace VotingApplication.Web.Tests.E2E
 
             [TestMethod]
             [TestCategory("E2E")]
-            public void PopulatedChoices_DisplaysChoiceDescriptions()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        Assert.AreEqual(poll.Choices.Count, choiceDescriptions.Count);
-
-                        List<string> expected = poll.Choices.Select(o => o.Description).ToList();
-                        List<string> actual = choiceDescriptions.Select(o => o.Text).ToList();
-                        CollectionAssert.AreEquivalent(expected, actual);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_TruncatesLongDescriptionsContainingAtLeastOneSpace()
-            {
-                const int truncationLength = 30;
-                string expectedText = new String('a', truncationLength) + "... Show More";
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', truncationLength) + " " + new String('a', truncationLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription + " " + tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_DoesNotTruncateLongDescriptionsContainingNoSpaces()
-            {
-                const int longDescriptionLength = 50;
-                string expectedText = new String('a', longDescriptionLength);
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', longDescriptionLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
             public void VotingOnChoice_NavigatesToResultsPage()
             {
                 using (IWebDriver driver = Driver)
@@ -146,7 +58,7 @@ namespace VotingApplication.Web.Tests.E2E
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        string expectedUriPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUriPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUriPrefix));
                     }
                 }
@@ -277,26 +189,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class InviteOnlyTests : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void AccessWithNoToken_DisplaysErrorPage()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        CreatePoll(context);
-
-                        GoToUrl(driver, PollUrl);
-
-                        IWebElement errorDirective = FindElementById(driver, "voting-partial-error");
-
-                        Assert.IsTrue(errorDirective.IsVisible());
-                    }
-                }
-            }
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -335,7 +228,7 @@ namespace VotingApplication.Web.Tests.E2E
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUrlPrefix));
                     }
                 }
@@ -629,7 +522,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class ElectionModeConfiguration : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod, TestCategory("E2E")]
             public void ElectionModePoll_DoesNotShowResultsButton()
@@ -665,7 +558,7 @@ namespace VotingApplication.Web.Tests.E2E
 
                         WaitForPageChange();
 
-                        string expectedUrl = SiteBaseUri + "Poll/#/Results/" + PollGuid;
+                        string expectedUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Results";
 
                         Assert.IsTrue(driver.Url.StartsWith(expectedUrl));
                     }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
@@ -20,7 +20,8 @@ namespace VotingApplication.Web.Tests.E2E
         public class DefaultPollConfiguration : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
+            private static readonly string PollVoteUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
+            private static readonly string PollResultsUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Results";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -31,7 +32,7 @@ namespace VotingApplication.Web.Tests.E2E
                     using (var context = new TestVotingContext())
                     {
                         Poll poll = CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
+                        GoToUrl(driver, PollVoteUrl);
 
                         IReadOnlyCollection<IWebElement> choiceNames = driver.FindElements(NgBy.Binding("choice.Name"));
 
@@ -52,18 +53,18 @@ namespace VotingApplication.Web.Tests.E2E
                 {
                     using (var context = new TestVotingContext())
                     {
-                        Poll poll = CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
+                        CreatePoll(context);
+                        GoToUrl(driver, PollVoteUrl);
 
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        string expectedUriPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
-                        Assert.IsTrue(driver.Url.StartsWith(expectedUriPrefix));
+                        Assert.IsTrue(driver.Url.StartsWith(PollResultsUrl));
                     }
                 }
             }
 
+            [Ignore]
             [TestMethod]
             [TestCategory("E2E")]
             public void DefaultPoll_ShowsResultsButton()
@@ -73,7 +74,7 @@ namespace VotingApplication.Web.Tests.E2E
                     using (var context = new TestVotingContext())
                     {
                         CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
+                        GoToUrl(driver, PollVoteUrl);
 
                         IWebElement resultsLink = FindElementById(driver, "results-button");
 
@@ -91,7 +92,7 @@ namespace VotingApplication.Web.Tests.E2E
                     using (var context = new TestVotingContext())
                     {
                         CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
+                        GoToUrl(driver, PollVoteUrl);
 
                         IWebElement voteButtons = FindElementById(driver, "vote-button");
                         voteButtons.Click();
@@ -114,7 +115,7 @@ namespace VotingApplication.Web.Tests.E2E
                     using (var context = new TestVotingContext())
                     {
                         CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
+                        GoToUrl(driver, PollVoteUrl);
 
                         IWebElement voteButtons = FindElementById(driver, "vote-button");
                         voteButtons.Click();
@@ -131,20 +132,6 @@ namespace VotingApplication.Web.Tests.E2E
 
                         Assert.IsFalse(ElementExists(driver, selectedChoiceLocator));
                     }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void NavigatingToNonExistentPoll_ShowsErrorPage()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    GoToUrl(driver, PollUrl);
-
-                    IWebElement errorDirective = FindElementById(driver, "voting-partial-error");
-
-                    Assert.IsTrue(errorDirective.IsVisible());
                 }
             }
 
@@ -270,25 +257,146 @@ namespace VotingApplication.Web.Tests.E2E
         }
 
         [TestClass]
-        public class NamedVotersPollConfiguration
+        public class NamedVotingTests : E2ETest
         {
-            private static ITestVotingContext _context;
-            private static Poll _namedBasicPoll;
+            const string VoterName = "User";
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
-            private IWebDriver _driver;
+            private static readonly string PollVoteUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
+            private static readonly string PollResultsUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Results";
 
-            [ClassInitialize]
-            public static void ClassInitialise(TestContext testContext)
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NoNameEntered_VoteNotAllowed()
             {
-                _context = new TestVotingContext();
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, PollVoteUrl);
 
-                List<Choice> testPollChoices = new List<Choice>() {
-                new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
-                new Choice(){ Name = "Test Choice 2", Description = "Test Description 2" }};
 
-                // Open, Named voters, No Choice Adding, Shown Results
-                _namedBasicPoll = new Poll()
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        Assert.IsFalse(driver.Url.StartsWith(PollResultsUrl));
+                        Assert.IsTrue(driver.Url.StartsWith(PollVoteUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NameEntered_VoteAllowed()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, PollVoteUrl);
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        Assert.IsTrue(driver.Url.StartsWith(PollResultsUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NoNameEntered_ShowsFailedValidationMessage()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, PollVoteUrl);
+
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        IWebElement requiredValidationMessage = FindElementById(driver, "voter-name-required-validation-message");
+
+                        Assert.IsTrue(requiredValidationMessage.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void EnteringVoterName_AllowsVoting()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, PollVoteUrl);
+
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        IWebElement requiredValidationMessage = FindElementById(driver, "voter-name-required-validation-message");
+
+                        Assert.IsTrue(requiredValidationMessage.IsVisible());
+
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        voteButton.Click();
+
+                        Assert.IsTrue(driver.Url.StartsWith(PollResultsUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void VotingAndReturning_RemembersVoterName()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, PollVoteUrl);
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IWebElement newNameInput = FindElementById(driver, "voter-name-input");
+
+                        Assert.AreEqual(VoterName, newNameInput.GetAttribute("value"));
+                    }
+                }
+            }
+
+            public static Poll CreateNamedVotersPoll(TestVotingContext testContext)
+            {
+                var testPollChoices = new List<Choice>() 
+                {
+                    new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
+                };
+
+                // Open, Anonymous, No Choice Adding, Shown Results
+                var namedVotersPoll = new Poll()
                 {
                     UUID = PollGuid,
                     PollType = PollType.Basic,
@@ -302,82 +410,10 @@ namespace VotingApplication.Web.Tests.E2E
                     ElectionMode = false
                 };
 
-                _context.Polls.Add(_namedBasicPoll);
-                _context.SaveChanges();
-            }
+                testContext.Polls.Add(namedVotersPoll);
+                testContext.SaveChanges();
 
-            [ClassCleanup]
-            public static void ClassCleanup()
-            {
-                PollClearer pollTearDown = new PollClearer(_context);
-                pollTearDown.ClearPoll(_namedBasicPoll);
-
-                _context.Dispose();
-            }
-
-            [TestInitialize]
-            public virtual void TestInitialise()
-            {
-                _driver = new NgWebDriver(new ChromeDriver(ChromeDriverDir));
-                _driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
-                _driver.Manage().Timeouts().SetPageLoadTimeout(TimeSpan.FromSeconds(10));
-            }
-
-            [TestCleanup]
-            public void TestCleanUp()
-            {
-                _driver.Dispose();
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void VoteWithNoName_PromptsForName()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IReadOnlyCollection<IWebElement> voteButtons = _driver.FindElements(By.Id("vote-button"));
-                voteButtons.First().Click();
-
-                Assert.AreEqual(SiteBaseUri + "Poll/#/Vote/" + _namedBasicPoll.UUID, _driver.Url);
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                Assert.IsTrue(formName.IsVisible());
-                Assert.AreEqual(String.Empty, formName.Text);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void NameInput_AcceptsValidName()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IReadOnlyCollection<IWebElement> voteButtons = _driver.FindElements(By.Id("vote-button"));
-                voteButtons.First().Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                IWebElement goButton = _driver.FindElement(By.Id("go-button"));
-
-                Assert.IsTrue(goButton.IsVisible());
-                Assert.IsFalse(goButton.Enabled);
-
-                formName.SendKeys("User");
-
-                Assert.IsTrue(goButton.Enabled);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void NameInput_VotesUponSubmission()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IReadOnlyCollection<IWebElement> voteButtons = _driver.FindElements(By.Id("vote-button"));
-                voteButtons.First().Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                formName.SendKeys("User");
-
-                IWebElement form = _driver.FindElement(By.Name("loginForm"));
-                form.Submit();
-
-                VoteClearer voterClearer = new VoteClearer(_context);
-                voterClearer.ClearLast();
-
-                Assert.IsTrue(_driver.Url.StartsWith(SiteBaseUri + "Poll/#/Results/" + _namedBasicPoll.UUID));
+                return namedVotersPoll;
             }
         }
 
@@ -522,9 +558,12 @@ namespace VotingApplication.Web.Tests.E2E
         public class ElectionModeConfiguration : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
+            private static readonly string PollVoteUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
+            private static readonly string PollResultsUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
-            [TestMethod, TestCategory("E2E")]
+            [Ignore]
+            [TestMethod]
+            [TestCategory("E2E")]
             public void ElectionModePoll_DoesNotShowResultsButton()
             {
                 using (IWebDriver driver = Driver)
@@ -532,7 +571,7 @@ namespace VotingApplication.Web.Tests.E2E
                     using (var context = new TestVotingContext())
                     {
                         Poll poll = CreateElectionPoll(context);
-                        GoToUrl(driver, PollUrl);
+                        GoToUrl(driver, PollVoteUrl);
 
                         IWebElement resultButton = FindElementById(driver, "results-button");
 
@@ -541,31 +580,31 @@ namespace VotingApplication.Web.Tests.E2E
                 }
             }
 
-            [TestMethod, TestCategory("E2E")]
+            [TestMethod]
+            [TestCategory("E2E")]
             public void ElectionModePoll_WithVotes_NavigatesToResults()
             {
                 using (IWebDriver driver = Driver)
                 {
                     using (var context = new TestVotingContext())
                     {
-                        Poll poll = CreateElectionPoll(context);
-                        GoToUrl(driver, PollUrl);
+                        CreateElectionPoll(context);
+                        GoToUrl(driver, PollVoteUrl);
 
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        GoToUrl(driver, PollUrl);
+                        GoToUrl(driver, PollVoteUrl);
 
                         WaitForPageChange();
 
-                        string expectedUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Results";
-
-                        Assert.IsTrue(driver.Url.StartsWith(expectedUrl));
+                        Assert.IsTrue(driver.Url.StartsWith(PollResultsUrl));
                     }
                 }
             }
 
-            [TestMethod, TestCategory("E2E")]
+            [TestMethod]
+            [TestCategory("E2E")]
             public void ElectionModeResults_WithoutVotes_NavigatesToVote()
             {
                 using (IWebDriver driver = Driver)
@@ -574,13 +613,13 @@ namespace VotingApplication.Web.Tests.E2E
                     {
                         Poll poll = CreateElectionPoll(context);
 
-                        string resultsUrl = PollUrl.Replace("Vote", "Results");
+                        string resultsUrl = PollVoteUrl.Replace("Vote", "Results");
 
-                        GoToUrl(driver, PollUrl);
+                        GoToUrl(driver, PollVoteUrl);
 
                         WaitForPageChange();
 
-                        Assert.AreEqual(PollUrl, driver.Url);
+                        Assert.AreEqual(PollVoteUrl, driver.Url);
                     }
                 }
             }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/BasicPollTests.cs
@@ -89,12 +89,15 @@ namespace VotingApplication.Web.Tests.E2E
                         CreatePoll(context);
                         GoToUrl(driver, PollVoteUrl);
 
-                        IWebElement voteButtons = FindElementById(driver, "vote-button");
-                        voteButtons.Click();
+                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Binding("choice.Name"));
+                        choices.First().Click();
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
 
                         NavigateBackToVotePage(driver);
 
-                        IWebElement selectedChoice = driver.FindElement(By.CssSelector(".selected-choice"));
+                        IWebElement selectedChoice = driver.FindElement(By.CssSelector(".md-ripple-visible"));
 
                         Assert.IsTrue(selectedChoice.IsVisible());
                     }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/CreationPageTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/CreationPageTests.cs
@@ -10,8 +10,9 @@ namespace VotingApplication.Web.Tests.E2E
     [TestClass]
     public class CreationPageTests : E2ETest
     {
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void QuickPoll_DisabledWhenQuestionHasNoText()
         {
             using (IWebDriver driver = Driver)
@@ -27,8 +28,9 @@ namespace VotingApplication.Web.Tests.E2E
             }
         }
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void CustomPoll_DisabledWhenQuestionHasNoText()
         {
             using (IWebDriver driver = Driver)
@@ -44,8 +46,9 @@ namespace VotingApplication.Web.Tests.E2E
             }
         }
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void QuickPoll_DisabledWhenOnlyQuestionHasText()
         {
             using (IWebDriver driver = Driver)
@@ -61,8 +64,9 @@ namespace VotingApplication.Web.Tests.E2E
             }
         }
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void QuickPoll_EnabledWhenQuestionAndChoiceHasText()
         {
             using (IWebDriver driver = Driver)
@@ -81,8 +85,9 @@ namespace VotingApplication.Web.Tests.E2E
             }
         }
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void CustomPoll_EnabledWhenQuestionHasText()
         {
             using (IWebDriver driver = Driver)
@@ -98,8 +103,9 @@ namespace VotingApplication.Web.Tests.E2E
             }
         }
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void QuickPoll_NavigatesToManagePollPage()
         {
             using (IWebDriver driver = Driver)
@@ -121,15 +127,16 @@ namespace VotingApplication.Web.Tests.E2E
 
                     Poll newPoll = context.Polls.Single();
 
-                    string expectedUrl = SiteBaseUri + "Poll/#/Vote/" + newPoll.UUID;
+                    string expectedUrl = SiteBaseUri + "Poll/#/" + newPoll.UUID + "/Vote";
 
                     Assert.AreEqual(expectedUrl, driver.Url);
                 }
             }
         }
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void CustomPoll_NavigatesToManagePollPage()
         {
             using (IWebDriver driver = Driver)
@@ -149,37 +156,6 @@ namespace VotingApplication.Web.Tests.E2E
                     Poll newPoll = context.Polls.Single();
 
                     string expectedUrl = SiteBaseUri + "Manage/#/Manage/" + newPoll.ManageId;
-
-                    Assert.AreEqual(expectedUrl, driver.Url);
-                }
-            }
-        }
-
-        [TestMethod]
-        [TestCategory("E2E")]
-        public void Register_Successfull_ShowsConfirmRegistration()
-        {
-            using (IWebDriver driver = Driver)
-            {
-                using (var context = new TestVotingContext())
-                {
-                    GoToBaseUri(driver);
-
-                    IWebElement registerLink = FindElementById(driver, "register-link");
-                    registerLink.Click();
-
-
-                    IWebElement emailInput = FindElementById(driver, "email");
-                    IWebElement passwordInput = FindElementById(driver, "password");
-                    IWebElement signInDialogButton = FindElementById(driver, "register-button-dialog");
-
-                    emailInput.SendKeys(NewUserEmail);
-                    passwordInput.SendKeys(NewUserPassword);
-                    signInDialogButton.Click();
-
-                    WaitForPageChange();
-
-                    string expectedUrl = SiteBaseUri + "Manage/#/ConfirmRegistration/" + NewUserEmail;
 
                     Assert.AreEqual(expectedUrl, driver.Url);
                 }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/E2ETest.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/E2ETest.cs
@@ -119,5 +119,15 @@ namespace VotingApplication.Web.Tests.E2E
                 dbContext.SaveChanges();
             }
         }
+
+        public static string GetPollVoteUrl(Guid pollId)
+        {
+            return SiteBaseUri + "Poll/#/" + pollId + "/Vote";
+        }
+
+        public static string GetPollResultsUrl(Guid pollId)
+        {
+            return SiteBaseUri + "Poll/#/" + pollId + "/Results";
+        }
     }
 }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
@@ -20,7 +20,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class DefaultPollConfiguration : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -46,94 +46,6 @@ namespace VotingApplication.Web.Tests.E2E
 
             [TestMethod]
             [TestCategory("E2E")]
-            public void PopulatedChoices_DisplaysChoiceDescriptions()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        Assert.AreEqual(poll.Choices.Count, choiceDescriptions.Count);
-
-                        List<string> expected = poll.Choices.Select(o => o.Description).ToList();
-                        List<string> actual = choiceDescriptions.Select(o => o.Text).ToList();
-                        CollectionAssert.AreEquivalent(expected, actual);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_TruncatesLongDescriptionsContainingAtLeastOneSpace()
-            {
-                const int truncationLength = 30;
-                string expectedText = new String('a', truncationLength) + "... Show More";
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', truncationLength) + " " + new String('a', truncationLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription + " " + tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_DoesNotTruncateLongDescriptionsContainingNoSpaces()
-            {
-                const int longDescriptionLength = 50;
-                string expectedText = new String('a', longDescriptionLength);
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', longDescriptionLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
             public void VotingOnChoice_NavigatesToResultsPage()
             {
                 using (IWebDriver driver = Driver)
@@ -146,7 +58,7 @@ namespace VotingApplication.Web.Tests.E2E
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        string expectedUriPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUriPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUriPrefix));
                     }
                 }
@@ -252,26 +164,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class InviteOnlyTests : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void AccessWithNoToken_DisplaysErrorPage()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        CreatePoll(context);
-
-                        GoToUrl(driver, PollUrl);
-
-                        IWebElement errorDirective = FindElementById(driver, "voting-partial-error");
-
-                        Assert.IsTrue(errorDirective.IsVisible());
-                    }
-                }
-            }
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -310,7 +203,7 @@ namespace VotingApplication.Web.Tests.E2E
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUrlPrefix));
                     }
                 }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
@@ -393,25 +393,96 @@ namespace VotingApplication.Web.Tests.E2E
         }
 
         [TestClass]
-        public class ChoiceAddingPollConfiguration
+        public class ChoiceAddingTests : E2ETest
         {
-            private static ITestVotingContext _context;
-            private static Poll _choiceAddingMultiPoll;
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
-            private IWebDriver _driver;
+            private static readonly string PollVoteUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
-            [ClassInitialize]
-            public static void ClassInitialise(TestContext testContext)
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void ChoiceAddingPoll_UserChoiceInputVisible()
             {
-                _context = new TestVotingContext();
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateChoiceAddingPoll(context);
 
-                List<Choice> testPollChoices = new List<Choice>() {
-                new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
-                new Choice(){ Name = "Test Choice 2", Description = "Test Description 2" }};
+                        GoToUrl(driver, PollVoteUrl);
 
-                // Open, Named voters, No Choice Adding, Shown Results
-                _choiceAddingMultiPoll = new Poll()
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+
+                        Assert.IsTrue(addChoiceInput.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NonChoiceAddingPoll_UserChoiceInputNotVisible()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        Poll poll = CreateChoiceAddingPoll(context);
+                        poll.ChoiceAdding = false;
+                        context.SaveChanges();
+
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+
+                        Assert.IsFalse(addChoiceInput.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void Add_AddsChoice()
+            {
+                const string newChoiceName = "NEW CHOICE";
+
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        Poll poll = CreateChoiceAddingPoll(context);
+
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+                        addChoiceInput.SendKeys(newChoiceName);
+
+                        IWebElement formButton = FindElementById(driver, "add-user-choice-button");
+                        formButton.Click();
+
+                        IReadOnlyCollection<IWebElement> choiceNames = driver.FindElements(NgBy.Binding("choice.Name"));
+
+                        Assert.AreEqual(poll.Choices.Count + 1, choiceNames.Count);
+                        Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
+
+                        // Refresh to ensure the new choice was stored in DB
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IReadOnlyCollection<IWebElement> choiceNamesAfterRefresh = driver.FindElements(NgBy.Binding("choice.Name"));
+
+                        Assert.AreEqual(poll.Choices.Count + 1, choiceNamesAfterRefresh.Count);
+                        Assert.AreEqual(newChoiceName, choiceNamesAfterRefresh.Last().Text);
+                    }
+                }
+            }
+
+            public static Poll CreateChoiceAddingPoll(TestVotingContext testContext)
+            {
+                var testPollChoices = new List<Choice>() 
+                {
+                    new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
+                };
+
+                // Open, Anonymous, Choice Adding, Shown Results
+                var choiceAddingMultiPoll = new Poll()
                 {
                     UUID = PollGuid,
                     PollType = PollType.Multi,
@@ -425,108 +496,10 @@ namespace VotingApplication.Web.Tests.E2E
                     ElectionMode = false
                 };
 
-                _context.Polls.Add(_choiceAddingMultiPoll);
-                _context.SaveChanges();
-            }
+                testContext.Polls.Add(choiceAddingMultiPoll);
+                testContext.SaveChanges();
 
-            [ClassCleanup]
-            public static void ClassCleanup()
-            {
-                PollClearer pollTearDown = new PollClearer(_context);
-                pollTearDown.ClearPoll(_choiceAddingMultiPoll);
-
-                _context.Dispose();
-            }
-
-            [TestInitialize]
-            public virtual void TestInitialise()
-            {
-                _driver = new NgWebDriver(new ChromeDriver(ChromeDriverDir));
-                _driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
-                _driver.Manage().Timeouts().SetPageLoadTimeout(TimeSpan.FromSeconds(10));
-            }
-
-            [TestCleanup]
-            public void TestCleanUp()
-            {
-                _driver.Dispose();
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingPoll_ProvidesLinkForAddingChoices()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-
-                Assert.IsTrue(addChoiceLink.IsVisible());
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingLink_PromptsForChoiceDetails()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                Assert.AreEqual(PollUrl, _driver.Url);
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-                Assert.IsTrue(formName.IsVisible());
-                Assert.AreEqual(String.Empty, formName.Text);
-
-                IWebElement formDescription = _driver.FindElement(NgBy.Model("addChoiceForm.description"));
-                Assert.IsTrue(formDescription.IsVisible());
-                Assert.AreEqual(String.Empty, formDescription.Text);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingPrompt_AcceptsValidName()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-                IWebElement addButton = _driver.FindElement(By.Id("add-button"));
-
-                Assert.IsTrue(addButton.IsVisible());
-                Assert.IsFalse(addButton.Enabled);
-
-                formName.SendKeys("New Choice");
-
-                Assert.IsTrue(addButton.Enabled);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingSubmission_AddsChoice()
-            {
-                _driver.Navigate().GoToUrl(PollUrl);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-
-                const string newChoiceName = "New Choice";
-                formName.SendKeys(newChoiceName);
-
-                IWebElement formButton = _driver.FindElement(By.Id("add-button"));
-                formButton.Click();
-
-                IReadOnlyCollection<IWebElement> choiceNames = _driver.FindElements(NgBy.Binding("choice.Name"));
-
-                Assert.AreEqual(_choiceAddingMultiPoll.Choices.Count + 1, choiceNames.Count);
-                Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
-
-                // Refresh to ensure the new choice was stored in DB
-                _driver.Navigate().GoToUrl(PollUrl);
-
-                choiceNames = _driver.FindElements(NgBy.Binding("choice.Name"));
-
-                Assert.AreEqual(_choiceAddingMultiPoll.Choices.Count + 1, choiceNames.Count);
-                Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
-
-                _choiceAddingMultiPoll.Choices.Remove(_choiceAddingMultiPoll.Choices.Last());
-                _context.SaveChanges();
+                return choiceAddingMultiPoll;
             }
         }
 

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
@@ -94,7 +94,7 @@ namespace VotingApplication.Web.Tests.E2E
                         CreatePoll(context);
                         GoToUrl(driver, GetPollVoteUrl(PollGuid));
 
-                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in choices"));
                         choices.First().Click();
 
                         IWebElement voteButton = FindElementById(driver, "vote-button");

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/MultiPollTests.cs
@@ -102,7 +102,7 @@ namespace VotingApplication.Web.Tests.E2E
 
                         NavigateBackToVotePage(driver);
 
-                        IWebElement selectedChoice = driver.FindElement(By.CssSelector(".selected-choice"));
+                        IWebElement selectedChoice = FindElementById(driver, "multi-choice-selected");
 
 
                         Assert.IsTrue(selectedChoice.IsVisible());

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/MyPollsPageTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/MyPollsPageTests.cs
@@ -13,8 +13,9 @@ namespace VotingApplication.Web.Tests.E2E
     {
         private static readonly Guid CreatedPollManageId = new Guid("FB74707A-C9D5-4B90-9F0C-D3280041B56C");
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void ExistingPoll_Manage_NavigatesToManagePollPage()
         {
             using (IWebDriver driver = Driver)
@@ -41,8 +42,9 @@ namespace VotingApplication.Web.Tests.E2E
             }
         }
 
+        [Ignore]
         [TestMethod]
-        [TestCategory("E2E")]
+        [TestCategory("E2ERewrite")]
         public void ExistingPoll_Repeat_NavigatesToNewPollManagePollPage()
         {
             using (IWebDriver driver = Driver)

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
@@ -44,7 +44,8 @@ namespace VotingApplication.Web.Tests.E2E
                 }
             }
 
-            [TestMethod, TestCategory("E2E")]
+            [TestMethod]
+            [TestCategory("E2E")]
             public void VotingOnChoice_NavigatesToResultsPage()
             {
                 using (IWebDriver driver = Driver)
@@ -67,6 +68,7 @@ namespace VotingApplication.Web.Tests.E2E
                 }
             }
 
+            [Ignore]
             [TestMethod]
             [TestCategory("E2E")]
             public void DefaultPoll_ShowsResultsButton()
@@ -249,20 +251,6 @@ namespace VotingApplication.Web.Tests.E2E
                 }
             }
 
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void NavigatingToNonExistentPoll_ShowsErrorPage()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    GoToUrl(driver, PollUrl);
-
-                    IWebElement errorDirective = FindElementById(driver, "voting-partial-error");
-
-                    Assert.IsTrue(errorDirective.IsVisible());
-                }
-            }
-
             public static Poll CreatePoll(TestVotingContext testContext)
             {
                 var testPollChoices = new List<Choice>() {
@@ -390,24 +378,146 @@ namespace VotingApplication.Web.Tests.E2E
         }
 
         [TestClass]
-        public class NamedVotersPollConfiguration
+        public class NamedVotingTests : E2ETest
         {
-            private static ITestVotingContext _context;
-            private static Poll _namedPointsPoll;
+            const string VoterName = "User";
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private IWebDriver _driver;
+            private readonly string _pollVoteUrl = GetPollVoteUrl(PollGuid);
+            private readonly string _pollResultsUrl = GetPollResultsUrl(PollGuid);
 
-            [ClassInitialize]
-            public static void ClassInitialise(TestContext testContext)
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NoNameEntered_VoteNotAllowed()
             {
-                _context = new TestVotingContext();
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
 
-                List<Choice> testPollChoices = new List<Choice>() {
-                new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
-                new Choice(){ Name = "Test Choice 2", Description = "Test Description 2" }};
 
-                // Open, Named voters, No Choice Adding, Shown Results
-                _namedPointsPoll = new Poll()
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        Assert.IsFalse(driver.Url.StartsWith(_pollResultsUrl));
+                        Assert.IsTrue(driver.Url.StartsWith(_pollVoteUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NameEntered_VoteAllowed()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        Assert.IsTrue(driver.Url.StartsWith(_pollResultsUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NoNameEntered_ShowsFailedValidationMessage()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        IWebElement requiredValidationMessage = FindElementById(driver, "voter-name-required-validation-message");
+
+                        Assert.IsTrue(requiredValidationMessage.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void EnteringVoterName_AllowsVoting()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        IWebElement requiredValidationMessage = FindElementById(driver, "voter-name-required-validation-message");
+
+                        Assert.IsTrue(requiredValidationMessage.IsVisible());
+
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        voteButton.Click();
+
+                        Assert.IsTrue(driver.Url.StartsWith(_pollResultsUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void VotingAndReturning_RemembersVoterName()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        GoToUrl(driver, _pollVoteUrl);
+
+                        IWebElement newNameInput = FindElementById(driver, "voter-name-input");
+
+                        Assert.AreEqual(VoterName, newNameInput.GetAttribute("value"));
+                    }
+                }
+            }
+
+            public static Poll CreateNamedVotersPoll(TestVotingContext testContext)
+            {
+                var testPollChoices = new List<Choice>() 
+                {
+                    new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
+                };
+
+                // Open, Anonymous, No Choice Adding, Shown Results
+                var namedVotersPoll = new Poll()
                 {
                     UUID = PollGuid,
                     PollType = PollType.Points,
@@ -418,90 +528,13 @@ namespace VotingApplication.Web.Tests.E2E
                     InviteOnly = false,
                     NamedVoting = true,
                     ChoiceAdding = false,
-                    ElectionMode = false,
-                    MaxPerVote = 3,
-                    MaxPoints = 4
+                    ElectionMode = false
                 };
 
-                _context.Polls.Add(_namedPointsPoll);
-                _context.SaveChanges();
-            }
+                testContext.Polls.Add(namedVotersPoll);
+                testContext.SaveChanges();
 
-            [ClassCleanup]
-            public static void ClassCleanup()
-            {
-                PollClearer pollTearDown = new PollClearer(_context);
-                pollTearDown.ClearPoll(_namedPointsPoll);
-
-                _context.Dispose();
-            }
-
-            [TestInitialize]
-            public virtual void TestInitialise()
-            {
-                _driver = new NgWebDriver(new ChromeDriver(ChromeDriverDir));
-                _driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
-                _driver.Manage().Timeouts().SetPageLoadTimeout(TimeSpan.FromSeconds(10));
-            }
-
-            [TestCleanup]
-            public void TestCleanUp()
-            {
-                _driver.Dispose();
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void VoteWithNoName_PromptsForName()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _namedPointsPoll.UUID);
-
-                IWebElement voteButton = _driver.FindElement(By.Id("vote-button"));
-                voteButton.Click();
-
-                Assert.AreEqual(SiteBaseUri + "Poll/#/Vote/" + _namedPointsPoll.UUID, _driver.Url);
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                Assert.IsTrue(formName.IsVisible());
-                Assert.AreEqual(String.Empty, formName.Text);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void NameInput_AcceptsValidName()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _namedPointsPoll.UUID);
-
-                IWebElement voteButton = _driver.FindElement(By.Id("vote-button"));
-                voteButton.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                IWebElement goButton = _driver.FindElement(By.Id("go-button"));
-
-                Assert.IsTrue(goButton.IsVisible());
-                Assert.IsFalse(goButton.Enabled);
-
-                formName.SendKeys("User");
-
-                Assert.IsTrue(goButton.Enabled);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void NameInput_VotesUponSubmission()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _namedPointsPoll.UUID);
-
-                IWebElement voteButton = _driver.FindElement(By.Id("vote-button"));
-                voteButton.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                formName.SendKeys("User");
-
-                IWebElement form = _driver.FindElement(By.Name("loginForm"));
-                form.Submit();
-
-                VoteClearer voterClearer = new VoteClearer(_context);
-                voterClearer.ClearLast();
-
-                Assert.IsTrue(_driver.Url.StartsWith(SiteBaseUri + "Poll/#/Results/" + _namedPointsPoll.UUID));
+                return namedVotersPoll;
             }
         }
 
@@ -705,7 +738,9 @@ namespace VotingApplication.Web.Tests.E2E
                 _driver.Dispose();
             }
 
-            [TestMethod, TestCategory("E2E")]
+            [Ignore]
+            [TestMethod]
+            [TestCategory("E2E")]
             public void ElectionModePoll_DoesNotShowResultsButton()
             {
                 _driver.Navigate().GoToUrl(PollUrl);

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
@@ -20,7 +20,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class DefaultPollConfiguration : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -44,94 +44,6 @@ namespace VotingApplication.Web.Tests.E2E
                 }
             }
 
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_DisplaysAllChoiceDescriptions()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        Assert.AreEqual(poll.Choices.Count, choiceDescriptions.Count);
-
-                        List<string> expected = poll.Choices.Select(o => o.Description).ToList();
-                        List<string> actual = choiceDescriptions.Select(o => o.Text).ToList();
-                        CollectionAssert.AreEquivalent(expected, actual);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_TruncatesLongDescriptionsContainingAtLeastOneSpace()
-            {
-                const int truncationLength = 30;
-                string expectedText = new String('a', truncationLength) + "... Show More";
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', truncationLength) + " " + new String('a', truncationLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription + " " + tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_DoesNotTruncateLongDescriptionsContainingNoSpaces()
-            {
-                const int longDescriptionLength = 50;
-                string expectedText = new String('a', longDescriptionLength);
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', longDescriptionLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
             [TestMethod, TestCategory("E2E")]
             public void VotingOnChoice_NavigatesToResultsPage()
             {
@@ -149,7 +61,7 @@ namespace VotingApplication.Web.Tests.E2E
                         voteButton.Click();
 
 
-                        string expectedUriPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUriPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUriPrefix));
                     }
                 }
@@ -394,26 +306,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class InviteOnlyTests : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void AccessWithNoToken_DisplaysErrorPage()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        CreatePoll(context);
-
-                        GoToUrl(driver, PollUrl);
-
-                        IWebElement errorDirective = FindElementById(driver, "voting-partial-error");
-
-                        Assert.IsTrue(errorDirective.IsVisible());
-                    }
-                }
-            }
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -452,7 +345,7 @@ namespace VotingApplication.Web.Tests.E2E
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUrlPrefix));
                     }
                 }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
@@ -98,10 +98,10 @@ namespace VotingApplication.Web.Tests.E2E
                         Poll poll = CreatePoll(context);
                         GoToUrl(driver, PollUrl);
 
-                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in choices"));
 
                         IWebElement firstChoice = choices.First();
-                        IWebElement selectedChoicePoints = firstChoice.FindElement(NgBy.Binding("choice.voteValue"));
+                        IWebElement selectedChoicePoints = firstChoice.FindElement(NgBy.Binding("choice.VoteValue"));
 
                         IReadOnlyCollection<IWebElement> increaseChoiceButtons = FindElementsById(driver, "increase-button");
                         IWebElement plusButton = increaseChoiceButtons.First();
@@ -109,12 +109,12 @@ namespace VotingApplication.Web.Tests.E2E
                         IReadOnlyCollection<IWebElement> decreaseChoiceButtons = FindElementsById(driver, "decrease-button");
                         IWebElement minusButton = decreaseChoiceButtons.First();
 
-                        string noPointsAllocatedPointsValue = "0/" + poll.MaxPerVote;
+                        string noPointsAllocatedPointsValue = "0 / " + poll.MaxPerVote;
 
                         Assert.AreEqual(noPointsAllocatedPointsValue, selectedChoicePoints.Text);
 
                         plusButton.Click();
-                        string onePointAllocatedPointsValue = "1/" + poll.MaxPerVote;
+                        string onePointAllocatedPointsValue = "1 / " + poll.MaxPerVote;
                         Assert.AreEqual(onePointAllocatedPointsValue, selectedChoicePoints.Text);
 
                         minusButton.Click();
@@ -134,7 +134,7 @@ namespace VotingApplication.Web.Tests.E2E
                         Poll poll = CreatePoll(context);
                         GoToUrl(driver, PollUrl);
 
-                        IWebElement totalPoints = FindElementById(driver, "points-display");
+                        IWebElement totalPoints = FindElementById(driver, "points-remaining");
 
                         IReadOnlyCollection<IWebElement> increaseChoiceButtons = FindElementsById(driver, "increase-button");
                         IWebElement plusButton = increaseChoiceButtons.First();
@@ -143,11 +143,11 @@ namespace VotingApplication.Web.Tests.E2E
                         IWebElement minusButton = decreaseChoiceButtons.First();
 
 
-                        string totalPointsNoneAllocated = "Unallocated points: " + poll.MaxPoints + "/" + poll.MaxPoints;
+                        string totalPointsNoneAllocated = poll.MaxPoints + " of " + poll.MaxPoints + " points remaining";
                         Assert.AreEqual(totalPointsNoneAllocated, totalPoints.Text);
 
                         plusButton.Click();
-                        string totalPointsOneAllocated = "Unallocated points: " + (poll.MaxPoints - 1) + "/" + poll.MaxPoints;
+                        string totalPointsOneAllocated = (poll.MaxPoints - 1) + " of " + poll.MaxPoints + " points remaining";
                         Assert.AreEqual(totalPointsOneAllocated, totalPoints.Text);
 
                         minusButton.Click();
@@ -193,7 +193,7 @@ namespace VotingApplication.Web.Tests.E2E
                         GoToUrl(driver, PollUrl);
 
 
-                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in choices"));
 
                         // Allocate maximum points (3 - see CreatePoll) to the first choice.
                         IWebElement firstChoice = choices.First();
@@ -226,7 +226,7 @@ namespace VotingApplication.Web.Tests.E2E
                         Poll poll = CreatePoll(context);
                         GoToUrl(driver, PollUrl);
 
-                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in choices"));
 
                         IWebElement choice = choices.First();
                         IWebElement increaseButton = choice.FindElement(By.Id("increase-button"));
@@ -237,7 +237,7 @@ namespace VotingApplication.Web.Tests.E2E
 
                         NavigateBackToVotePage(driver);
 
-                        IReadOnlyCollection<IWebElement> selectedChoices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> selectedChoices = driver.FindElements(NgBy.Repeater("choice in choices"));
 
                         IWebElement selectedChoice = selectedChoices.First();
                         IWebElement selectedChoicePoints = selectedChoice.FindElement(NgBy.Binding("poll.MaxPerVote"));
@@ -245,7 +245,7 @@ namespace VotingApplication.Web.Tests.E2E
 
                         Assert.IsTrue(selectedChoicePoints.IsVisible());
 
-                        string expectedChoicePoints = "1/" + poll.MaxPerVote;
+                        string expectedChoicePoints = "1 / " + poll.MaxPerVote;
                         Assert.AreEqual(expectedChoicePoints, selectedChoicePoints.Text);
                     }
                 }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
@@ -33,7 +33,7 @@ namespace VotingApplication.Web.Tests.E2E
                         Poll poll = CreatePoll(context);
                         GoToUrl(driver, PollUrl);
 
-                        IReadOnlyCollection<IWebElement> choiceNames = driver.FindElements(NgBy.Binding("choice.Name"));
+                        IReadOnlyCollection<IWebElement> choiceNames = FindElementsById(driver, "points-choice-name");
 
                         Assert.AreEqual(poll.Choices.Count, choiceNames.Count);
 
@@ -307,7 +307,7 @@ namespace VotingApplication.Web.Tests.E2E
                         Poll poll = CreatePoll(context);
 
                         GoToUrl(driver, PollUrl + "/" + poll.Ballots[0].TokenGuid);
-                        IReadOnlyCollection<IWebElement> choiceNames = driver.FindElements(NgBy.Binding("choice.Name"));
+                        IReadOnlyCollection<IWebElement> choiceNames = FindElementsById(driver, "points-choice-name");
 
                         Assert.AreEqual(poll.Choices.Count, choiceNames.Count);
 

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/PointsPollTests.cs
@@ -539,24 +539,96 @@ namespace VotingApplication.Web.Tests.E2E
         }
 
         [TestClass]
-        public class ChoiceAddingPollConfiguration
+        public class ChoiceAddingTests : E2ETest
         {
-            private static ITestVotingContext _context;
-            private static Poll _choiceAddingPointsPoll;
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private IWebDriver _driver;
+            private static readonly string PollVoteUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
-            [ClassInitialize]
-            public static void ClassInitialise(TestContext testContext)
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void ChoiceAddingPoll_UserChoiceInputVisible()
             {
-                _context = new TestVotingContext();
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateChoiceAddingPoll(context);
 
-                List<Choice> testPollChoices = new List<Choice>() {
-                new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
-                new Choice(){ Name = "Test Choice 2", Description = "Test Description 2" }};
+                        GoToUrl(driver, PollVoteUrl);
 
-                // Open, Named voters, No Choice Adding, Shown Results
-                _choiceAddingPointsPoll = new Poll()
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+
+                        Assert.IsTrue(addChoiceInput.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NonChoiceAddingPoll_UserChoiceInputNotVisible()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        Poll poll = CreateChoiceAddingPoll(context);
+                        poll.ChoiceAdding = false;
+                        context.SaveChanges();
+
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+
+                        Assert.IsFalse(addChoiceInput.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void Add_AddsChoice()
+            {
+                const string newChoiceName = "NEW CHOICE";
+
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        Poll poll = CreateChoiceAddingPoll(context);
+
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IWebElement addChoiceInput = FindElementById(driver, "user-choice-input");
+                        addChoiceInput.SendKeys(newChoiceName);
+
+                        IWebElement formButton = FindElementById(driver, "add-user-choice-button");
+                        formButton.Click();
+
+                        IReadOnlyCollection<IWebElement> choiceNames = driver.FindElements(NgBy.Binding("choice.Name"));
+
+                        Assert.AreEqual(poll.Choices.Count + 1, choiceNames.Count);
+                        Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
+
+                        // Refresh to ensure the new choice was stored in DB
+                        GoToUrl(driver, PollVoteUrl);
+
+                        IReadOnlyCollection<IWebElement> choiceNamesAfterRefresh = driver.FindElements(NgBy.Binding("choice.Name"));
+
+                        Assert.AreEqual(poll.Choices.Count + 1, choiceNamesAfterRefresh.Count);
+                        Assert.AreEqual(newChoiceName, choiceNamesAfterRefresh.Last().Text);
+                    }
+                }
+            }
+
+            public static Poll CreateChoiceAddingPoll(TestVotingContext testContext)
+            {
+                var testPollChoices = new List<Choice>() 
+                {
+                    new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
+                };
+
+                // Open, Anonymous, Choice Adding, Shown Results
+                var choiceAddingPointsPoll = new Poll()
                 {
                     UUID = PollGuid,
                     PollType = PollType.Points,
@@ -567,111 +639,13 @@ namespace VotingApplication.Web.Tests.E2E
                     InviteOnly = false,
                     NamedVoting = false,
                     ChoiceAdding = true,
-                    ElectionMode = false,
-                    MaxPerVote = 3,
-                    MaxPoints = 4
+                    ElectionMode = false
                 };
 
-                _context.Polls.Add(_choiceAddingPointsPoll);
-                _context.SaveChanges();
-            }
+                testContext.Polls.Add(choiceAddingPointsPoll);
+                testContext.SaveChanges();
 
-            [ClassCleanup]
-            public static void ClassCleanup()
-            {
-                PollClearer pollTearDown = new PollClearer(_context);
-                pollTearDown.ClearPoll(_choiceAddingPointsPoll);
-
-                _context.Dispose();
-            }
-
-            [TestInitialize]
-            public virtual void TestInitialise()
-            {
-                _driver = new NgWebDriver(new ChromeDriver(ChromeDriverDir));
-                _driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
-                _driver.Manage().Timeouts().SetPageLoadTimeout(TimeSpan.FromSeconds(10));
-            }
-
-            [TestCleanup]
-            public void TestCleanUp()
-            {
-                _driver.Dispose();
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingPoll_ProvidesLinkForAddingChoices()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _choiceAddingPointsPoll.UUID);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-
-                Assert.IsTrue(addChoiceLink.IsVisible());
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingLink_PromptsForChoiceDetails()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _choiceAddingPointsPoll.UUID);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                Assert.AreEqual(SiteBaseUri + "Poll/#/Vote/" + _choiceAddingPointsPoll.UUID, _driver.Url);
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-                Assert.IsTrue(formName.IsVisible());
-                Assert.AreEqual(String.Empty, formName.Text);
-
-                IWebElement formDescription = _driver.FindElement(NgBy.Model("addChoiceForm.description"));
-                Assert.IsTrue(formDescription.IsVisible());
-                Assert.AreEqual(String.Empty, formDescription.Text);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingPrompt_AcceptsValidName()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _choiceAddingPointsPoll.UUID);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-
-                IWebElement addButton = _driver.FindElement(By.Id("add-button"));
-
-                Assert.IsTrue(addButton.IsVisible());
-                Assert.IsFalse(addButton.Enabled);
-
-                formName.SendKeys("New Choice");
-
-                Assert.IsTrue(addButton.Enabled);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void ChoiceAddingSubmission_AddsChoice()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _choiceAddingPointsPoll.UUID);
-                IWebElement addChoiceLink = _driver.FindElement(By.Id("add-choice-link"));
-                addChoiceLink.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("addChoiceForm.name"));
-
-                const string newChoiceName = "New Choice";
-                formName.SendKeys(newChoiceName);
-
-                IWebElement formButton = _driver.FindElement(By.Id("add-button"));
-                formButton.Click();
-
-                IReadOnlyCollection<IWebElement> choiceNames = _driver.FindElements(NgBy.Binding("choice.Name"));
-
-                Assert.AreEqual(_choiceAddingPointsPoll.Choices.Count + 1, choiceNames.Count);
-                Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
-
-                // Refresh to ensure they new choice was stored in DB
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _choiceAddingPointsPoll.UUID);
-
-                choiceNames = _driver.FindElements(NgBy.Binding("choice.Name"));
-
-                Assert.AreEqual(_choiceAddingPointsPoll.Choices.Count + 1, choiceNames.Count);
-                Assert.AreEqual(newChoiceName, choiceNames.Last().Text);
+                return choiceAddingPointsPoll;
             }
         }
 

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/UpDownPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/UpDownPollTests.cs
@@ -54,7 +54,7 @@ namespace VotingApplication.Web.Tests.E2E
                     {
                         Poll poll = CreatePoll(context);
                         GoToUrl(driver, PollUrl);
-                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in choices"));
 
                         IReadOnlyCollection<IWebElement> firstChoiceButtons = choices.First().FindElements(By.TagName("Button"));
                         IWebElement downButton = firstChoiceButtons.First();
@@ -98,7 +98,7 @@ namespace VotingApplication.Web.Tests.E2E
                         CreatePoll(context);
                         GoToUrl(driver, PollUrl);
 
-                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> choices = driver.FindElements(NgBy.Repeater("choice in choices"));
 
                         IReadOnlyCollection<IWebElement> firstChoiceButtons = choices.First().FindElements(By.TagName("Button"));
                         IWebElement downButton = firstChoiceButtons.First();
@@ -109,9 +109,9 @@ namespace VotingApplication.Web.Tests.E2E
 
                         NavigateBackToVotePage(driver);
 
-                        IReadOnlyCollection<IWebElement> selectedChoices = driver.FindElements(NgBy.Repeater("choice in poll.Choices"));
+                        IReadOnlyCollection<IWebElement> selectedChoices = driver.FindElements(NgBy.Repeater("choice in choices"));
                         IWebElement selectedChoice = selectedChoices.First();
-                        IWebElement selectedChoiceButton = selectedChoice.FindElement(By.CssSelector(".active-btn"));
+                        IWebElement selectedChoiceButton = selectedChoice.FindElement(By.CssSelector(".md-accent"));
 
 
                         Assert.IsTrue(selectedChoiceButton.IsVisible());

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/UpDownPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/UpDownPollTests.cs
@@ -20,7 +20,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class DefaultPollConfiguration : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -46,94 +46,6 @@ namespace VotingApplication.Web.Tests.E2E
 
             [TestMethod]
             [TestCategory("E2E")]
-            public void PopulatedChoices_DisplaysChoiceDescriptions()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        Assert.AreEqual(poll.Choices.Count, choiceDescriptions.Count);
-
-                        List<string> expected = poll.Choices.Select(o => o.Description).ToList();
-                        List<string> actual = choiceDescriptions.Select(o => o.Text).ToList();
-                        CollectionAssert.AreEquivalent(expected, actual);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_TruncatesLongDescriptionsContainingAtLeastOneSpace()
-            {
-                const int truncationLength = 30;
-                string expectedText = new String('a', truncationLength) + "... Show More";
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', truncationLength) + " " + new String('a', truncationLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription + " " + tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void PopulatedChoices_DoesNotTruncateLongDescriptionsContainingNoSpaces()
-            {
-                const int longDescriptionLength = 50;
-                string expectedText = new String('a', longDescriptionLength);
-
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        Poll poll = CreatePoll(context);
-
-                        string tooLongChoiceDescription = new String('a', longDescriptionLength);
-
-                        poll.Choices.Add(new Choice()
-                        {
-                            Name = "Test Choice 2",
-                            Description = tooLongChoiceDescription
-                        });
-                        context.SaveChanges();
-
-
-                        GoToUrl(driver, PollUrl);
-
-                        IReadOnlyCollection<IWebElement> choiceDescriptions = driver.FindElements(NgBy.Model("choice.Description"));
-
-                        string selectedChoiceText = choiceDescriptions.Select(o => o.Text).Last();
-                        Assert.AreEqual(expectedText, selectedChoiceText);
-                    }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
             public void VotingOnChoice_NavigatesToResultsPage()
             {
                 using (IWebDriver driver = Driver)
@@ -151,7 +63,7 @@ namespace VotingApplication.Web.Tests.E2E
                         IWebElement voteButton = FindElementById(driver, "vote-button");
                         voteButton.Click();
 
-                        string expectedUriPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUriPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUriPrefix));
                     }
                 }
@@ -261,26 +173,7 @@ namespace VotingApplication.Web.Tests.E2E
         public class InviteOnlyTests : E2ETest
         {
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private static readonly string PollUrl = SiteBaseUri + "Poll/#/Vote/" + PollGuid;
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void AccessWithNoToken_DisplaysErrorPage()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    using (var context = new TestVotingContext())
-                    {
-                        CreatePoll(context);
-
-                        GoToUrl(driver, PollUrl);
-
-                        IWebElement errorDirective = FindElementById(driver, "voting-partial-error");
-
-                        Assert.IsTrue(errorDirective.IsVisible());
-                    }
-                }
-            }
+            private static readonly string PollUrl = SiteBaseUri + "Poll/#/" + PollGuid + "/Vote";
 
             [TestMethod]
             [TestCategory("E2E")]
@@ -319,7 +212,7 @@ namespace VotingApplication.Web.Tests.E2E
                         IReadOnlyCollection<IWebElement> voteButtons = FindElementsById(driver, "vote-button");
                         voteButtons.First().Click();
 
-                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/Results/" + poll.UUID;
+                        string expectedUrlPrefix = SiteBaseUri + "Poll/#/" + poll.UUID + "/Results";
                         Assert.IsTrue(driver.Url.StartsWith(expectedUrlPrefix));
                     }
                 }

--- a/VotingApplication/VotingApplication.Web.Tests/E2E/UpDownPollTests.cs
+++ b/VotingApplication/VotingApplication.Web.Tests/E2E/UpDownPollTests.cs
@@ -69,6 +69,7 @@ namespace VotingApplication.Web.Tests.E2E
                 }
             }
 
+            [Ignore]
             [TestMethod]
             [TestCategory("E2E")]
             public void DefaultPoll_ShowsResultsButton()
@@ -115,20 +116,6 @@ namespace VotingApplication.Web.Tests.E2E
 
                         Assert.IsTrue(selectedChoiceButton.IsVisible());
                     }
-                }
-            }
-
-            [TestMethod]
-            [TestCategory("E2E")]
-            public void NavigatingToNonExistentPoll_ShowsErrorPage()
-            {
-                using (IWebDriver driver = Driver)
-                {
-                    GoToUrl(driver, PollUrl);
-
-                    IWebElement errorDirective = FindElementById(driver, "voting-partial-error");
-
-                    Assert.IsTrue(errorDirective.IsVisible());
                 }
             }
 
@@ -254,24 +241,146 @@ namespace VotingApplication.Web.Tests.E2E
         }
 
         [TestClass]
-        public class NamedVotersPollConfiguration
+        public class NamedVotingTests : E2ETest
         {
-            private static ITestVotingContext _context;
-            private static Poll _namedUpDownPoll;
+            const string VoterName = "User";
             private static readonly Guid PollGuid = Guid.NewGuid();
-            private IWebDriver _driver;
+            private readonly string _pollVoteUrl = GetPollVoteUrl(PollGuid);
+            private readonly string _pollResultsUrl = GetPollResultsUrl(PollGuid);
 
-            [ClassInitialize]
-            public static void ClassInitialise(TestContext testContext)
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NoNameEntered_VoteNotAllowed()
             {
-                _context = new TestVotingContext();
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
 
-                List<Choice> testPollChoices = new List<Choice>() {
-                new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
-                new Choice(){ Name = "Test Choice 2", Description = "Test Description 2" }};
 
-                // Open, Named voters, No Choice Adding, Shown Results
-                _namedUpDownPoll = new Poll()
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        Assert.IsFalse(driver.Url.StartsWith(_pollResultsUrl));
+                        Assert.IsTrue(driver.Url.StartsWith(_pollVoteUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NameEntered_VoteAllowed()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        Assert.IsTrue(driver.Url.StartsWith(_pollResultsUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void NoNameEntered_ShowsFailedValidationMessage()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        IWebElement requiredValidationMessage = FindElementById(driver, "voter-name-required-validation-message");
+
+                        Assert.IsTrue(requiredValidationMessage.IsVisible());
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void EnteringVoterName_AllowsVoting()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        IWebElement requiredValidationMessage = FindElementById(driver, "voter-name-required-validation-message");
+
+                        Assert.IsTrue(requiredValidationMessage.IsVisible());
+
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        voteButton.Click();
+
+                        Assert.IsTrue(driver.Url.StartsWith(_pollResultsUrl));
+                    }
+                }
+            }
+
+            [TestMethod]
+            [TestCategory("E2E")]
+            public void VotingAndReturning_RemembersVoterName()
+            {
+                using (IWebDriver driver = Driver)
+                {
+                    using (var context = new TestVotingContext())
+                    {
+                        CreateNamedVotersPoll(context);
+                        GoToUrl(driver, _pollVoteUrl);
+
+
+                        IWebElement nameInput = FindElementById(driver, "voter-name-input");
+                        nameInput.SendKeys(VoterName);
+
+                        IWebElement voteButton = FindElementById(driver, "vote-button");
+                        voteButton.Click();
+
+                        GoToUrl(driver, _pollVoteUrl);
+
+                        IWebElement newNameInput = FindElementById(driver, "voter-name-input");
+
+                        Assert.AreEqual(VoterName, newNameInput.GetAttribute("value"));
+                    }
+                }
+            }
+
+            public static Poll CreateNamedVotersPoll(TestVotingContext testContext)
+            {
+                var testPollChoices = new List<Choice>() 
+                {
+                    new Choice(){ Name = "Test Choice 1", Description = "Test Description 1" },
+                };
+
+                // Open, Anonymous, No Choice Adding, Shown Results
+                var namedVotersPoll = new Poll()
                 {
                     UUID = PollGuid,
                     PollType = PollType.UpDown,
@@ -285,83 +394,10 @@ namespace VotingApplication.Web.Tests.E2E
                     ElectionMode = false
                 };
 
-                _context.Polls.Add(_namedUpDownPoll);
-                _context.SaveChanges();
-            }
+                testContext.Polls.Add(namedVotersPoll);
+                testContext.SaveChanges();
 
-            [ClassCleanup]
-            public static void ClassCleanup()
-            {
-                PollClearer pollTearDown = new PollClearer(_context);
-                pollTearDown.ClearPoll(_namedUpDownPoll);
-
-                _context.Dispose();
-            }
-
-            [TestInitialize]
-            public virtual void TestInitialise()
-            {
-                _driver = new NgWebDriver(new ChromeDriver(ChromeDriverDir));
-                _driver.Manage().Timeouts().SetScriptTimeout(TimeSpan.FromSeconds(10));
-                _driver.Manage().Timeouts().SetPageLoadTimeout(TimeSpan.FromSeconds(10));
-            }
-
-            [TestCleanup]
-            public void TestCleanUp()
-            {
-                _driver.Dispose();
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void VoteWithNoName_PromptsForName()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _namedUpDownPoll.UUID);
-                IWebElement voteButton = _driver.FindElement(By.Id("vote-button"));
-                voteButton.Click();
-
-                Assert.AreEqual(SiteBaseUri + "Poll/#/Vote/" + _namedUpDownPoll.UUID, _driver.Url);
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                Assert.IsTrue(formName.IsVisible());
-                Assert.AreEqual(String.Empty, formName.Text);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void NameInput_AcceptsValidName()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _namedUpDownPoll.UUID);
-                IWebElement voteButton = _driver.FindElement(By.Id("vote-button"));
-                voteButton.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                IWebElement goButton = _driver.FindElement(By.Id("go-button"));
-
-                Assert.IsTrue(goButton.IsVisible());
-                Assert.IsFalse(goButton.Enabled);
-
-                formName.SendKeys("User");
-
-                Assert.IsTrue(goButton.Enabled);
-            }
-
-            [TestMethod, TestCategory("E2E")]
-            public void NameInput_VotesUponSubmission()
-            {
-                _driver.Navigate().GoToUrl(SiteBaseUri + "Poll/#/Vote/" + _namedUpDownPoll.UUID);
-
-                IWebElement voteButton = _driver.FindElement(By.Id("vote-button"));
-                voteButton.Click();
-
-                IWebElement formName = _driver.FindElement(NgBy.Model("loginForm.name"));
-                formName.SendKeys("User");
-
-                IWebElement form = _driver.FindElement(By.Name("loginForm"));
-                form.Submit();
-
-                VoteClearer voterClearer = new VoteClearer(_context);
-                voterClearer.ClearLast();
-
-                Assert.IsTrue(_driver.Url.StartsWith(SiteBaseUri + "Poll/#/Results/" + _namedUpDownPoll.UUID));
+                return namedVotersPoll;
             }
         }
 
@@ -561,7 +597,9 @@ namespace VotingApplication.Web.Tests.E2E
                 _driver.Dispose();
             }
 
-            [TestMethod, TestCategory("E2E")]
+            [Ignore]
+            [TestMethod]
+            [TestCategory("E2E")]
             public void ElectionModePoll_DoesNotShowResultsButton()
             {
                 _driver.Navigate().GoToUrl(PollUrl);

--- a/VotingApplication/VotingApplication.Web/Scripts/Directives/VoteChoice/VoteChoiceTypes/MultiVoteChoice.html
+++ b/VotingApplication/VotingApplication.Web/Scripts/Directives/VoteChoice/VoteChoiceTypes/MultiVoteChoice.html
@@ -1,7 +1,6 @@
 ﻿<md-list>
     <md-list-item ng-repeat="choice in choices">
-        <md-checkbox ng-model="choice.selected" aria-label="Selected" ng-change="selectedChanged(choice)"></md-checkbox>
+        <md-checkbox id="multi-choice-selected" ng-model="choice.selected" aria-label="Selected" ng-change="selectedChanged(choice)"></md-checkbox>
         <p >{{choice.Name}}</p>
-        
     </md-list-item>
 </md-list>

--- a/VotingApplication/VotingApplication.Web/Scripts/Directives/VoteChoice/VoteChoiceTypes/PointsVoteChoice.html
+++ b/VotingApplication/VotingApplication.Web/Scripts/Directives/VoteChoice/VoteChoiceTypes/PointsVoteChoice.html
@@ -1,13 +1,25 @@
-﻿<span>{{pointsRemaining }} of {{poll.MaxPoints}} points remaining</span>
+﻿<span id="points-remaining">{{pointsRemaining }} of {{poll.MaxPoints}} points remaining</span>
 <md-progress-linear class="md-accent" md-mode="determinate" value="{{percentagePointsRemaining}}"></md-progress-linear>
 
 <md-list>
     <md-list-item ng-repeat="choice in choices">
         {{choice.Name}}
         <span flex></span>
-        <md-button class="md-icon-button" ng-click="decreasePoints(choice)" ng-disabled="decreasePointsDisabled(choice)" aria-label="Decrease Points">-</md-button>
+        <md-button id="decrease-button"
+                   class="md-icon-button"
+                   ng-click="decreasePoints(choice)"
+                   ng-disabled="decreasePointsDisabled(choice)"
+                   aria-label="Decrease Points">
+            -
+        </md-button>
         <label>{{choice.VoteValue}} / {{poll.MaxPerVote}}</label>
-        <md-button class="md-icon-button" ng-click="increasePoints(choice)" ng-disabled="increasePointsDisabled(choice)" aria-label="Increase Points">+</md-button>
+        <md-button id="increase-button"
+                   class="md-icon-button"
+                   ng-click="increasePoints(choice)"
+                   ng-disabled="increasePointsDisabled(choice)"
+                   aria-label="Increase Points">
+            +
+        </md-button>
 
     </md-list-item>
 </md-list>

--- a/VotingApplication/VotingApplication.Web/Scripts/Directives/VoteChoice/VoteChoiceTypes/PointsVoteChoice.html
+++ b/VotingApplication/VotingApplication.Web/Scripts/Directives/VoteChoice/VoteChoiceTypes/PointsVoteChoice.html
@@ -3,7 +3,7 @@
 
 <md-list>
     <md-list-item ng-repeat="choice in choices">
-        {{choice.Name}}
+        <span id="points-choice-name">{{choice.Name}}</span>
         <span flex></span>
         <md-button id="decrease-button"
                    class="md-icon-button"

--- a/VotingApplication/VotingApplication.Web/Views/Poll/Vote.cshtml
+++ b/VotingApplication/VotingApplication.Web/Views/Poll/Vote.cshtml
@@ -68,7 +68,7 @@
             </div>
 
             <div layout="row" layout-sm="column" layout-align-gt-sm="end center">
-                <md-button class="md-primary md-raised" ng-click="castVote()" ng-disabled="submitting">
+                <md-button id="vote-button" class="md-primary md-raised" ng-click="castVote()" ng-disabled="submitting">
                     Vote
                 </md-button>
             </div>

--- a/VotingApplication/VotingApplication.Web/Views/Poll/Vote.cshtml
+++ b/VotingApplication/VotingApplication.Web/Views/Poll/Vote.cshtml
@@ -37,9 +37,9 @@
             <div ng-show="poll.ChoiceAdding" layout layout-margin hide-sm>
                 <md-input-container>
                     <label>Add your own choice</label>
-                    <input ng-model="userChoice" ng-disabled="submitting">
+                    <input id="user-choice-input" ng-model="userChoice" ng-disabled="submitting">
                 </md-input-container>
-                <md-button class="md-icon-button" ng-click="addChoiceFromPage(userChoice)" ng-disabled="submitting">
+                <md-button id="add-user-choice-button" class="md-icon-button" ng-click="addChoiceFromPage(userChoice)" ng-disabled="submitting">
                     <md-icon md-font-icon="fa-plus fa-lg" class="fa vo-button-margin-top"></md-icon>
                 </md-button>
                 <span flex></span>

--- a/VotingApplication/VotingApplication.Web/Views/Poll/Vote.cshtml
+++ b/VotingApplication/VotingApplication.Web/Views/Poll/Vote.cshtml
@@ -22,10 +22,10 @@
                                 <md-icon md-font-icon="fa-user" class="fa" alt="user"></md-icon>
                                 Your name
                             </label>
-                            <input ng-model="voterIdentity.name" name="voterName" required>
+                            <input id="voter-name-input" ng-model="voterIdentity.name" name="voterName" required>
 
                             <div ng-messages="voterNameForm.voterName.$error" ng-if="voteClicked">
-                                <span ng-message="required">You must supply a name</span>
+                                <span id="voter-name-required-validation-message" ng-message="required">You must supply a name</span>
                             </div>
                         </md-input-container>
                     </form>
@@ -58,10 +58,10 @@
                             <md-icon md-font-icon="fa-user" class="fa" alt="user"></md-icon>
                             Your name
                         </label>
-                        <input ng-model="voterIdentity.name" name="voterName" required>
+                        <input id="voter-name-input" ng-model="voterIdentity.name" name="voterName" required>
 
                         <div ng-messages="voterNameForm.voterName.$error" ng-if="voteClicked">
-                            <span ng-message="required">You must supply a name</span>
+                            <span id="voter-name-required-validation-message" ng-message="required">You must supply a name</span>
                         </div>
                     </md-input-container>
                 </form>


### PR DESCRIPTION
Fixes the majority of failing E2E tests.
Removed unnecessary tests.
Marked tests which may or may not be correct with `[Ignore]` and trait of "E2ERewrite". Examples are the Results link tests, as we need to confirm whether we should have a link or not.